### PR TITLE
Use the EventEmitter pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,5 @@ obj/*
 typings/
 dist/
 output/
-client/examples/js/lib/
-processor/examples/js/lib/
+out/
 typedoc

--- a/.npmignore
+++ b/.npmignore
@@ -45,3 +45,4 @@ typedoc/
 # coverage #
 .nyc_output
 coverage
+out/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,12 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Launch Program",
-            "program": "${file}"
+            "name": "examples",
+            "program": "${workspaceFolder}/examples/send.ts",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "envFile": "${workspaceFolder}/.env" // You can take a look at the sample.env file for supported environment variables.
         }
     ]
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at opensource@microsoft.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -2,19 +2,62 @@
 
 A Promisified layer over rhea AMQP client.
 
-### Examples
+## Pre-requisite ##
+- **Node.js version: 8.x or higher.** We would encourage you to install the latest available LTS version at any given time from https://nodejs.org. Please **do not** use older LTS versions of node.js.
+
+## Installation ##
+```bash
+npm install rhea-promise
+```
+
+## Debug logs ##
+
+You can set the following environment variable to get the debug logs.
+
+- Getting debug logs from the library
+```bash
+export DEBUG=rhea*
+```
+- If you are **not interested in viewing the message transformation** (which consumes lot of console/disk space) then you can set the `DEBUG` environment variable as follows:
+```bash
+export DEBUG=rhea*,-rhea:raw,-rhea:message
+```
+
+#### Logging to a file
+- Set the `DEBUG` environment variable as shown above and then run your test script as follows:
+  - Logging statements from you test script go to `out.log` and logging statement from the sdk go to `debug.log`.
+    ```bash
+    node your-test-script.js > out.log 2>debug.log
+    ```
+  - Logging statements from your test script and the sdk go to the same file `out.log` by redirecting stderr to stdout (&1), and then redirect stdout to a file:
+    ```bash
+    node your-test-script.js >out.log 2>&1
+    ```
+  - Logging statements from your test script and the sdk go to the same file `out.log`.
+    ```bash
+      node your-test-script.js &> out.log
+    ```
+
+
+## Examples
+
+Please take a look at the [sample.env](https://github.com/amqp/rhea-promise/blob/master/sample.env) file for examples on how to provide the values for different 
+parameters like host, username, password, port, senderAddress, receiverAddress, etc.
 
 #### Sending a message.
+- Running the example from terminal: `> ts-node ./examples/send.ts`.
+
+**NOTE:** If you are running the sample with `.env` config file, then please run the sample from the directory that contains `.env` config file. 
 ```ts
 import {
   Connection, Sender, EventContext, Message, ConnectionOptions, Delivery, SenderOptions
 } from "rhea-promise";
-
 import * as dotenv from "dotenv"; // Optional for loading environment configuration from a .env (config) file
 dotenv.config();
 
 const host = process.env.AMQP_HOST || "host";
-const username = process.env.AMQP_USERNAME || "username";
+const username = process.env.AMQP_USERNAME || "sharedAccessKeyName";
+const password = process.env.AMQP_PASSWORD || "sharedAccessKeyValue";
 const port = parseInt(process.env.AMQP_PORT || "5671");
 const senderAddress = process.env.SENDER_ADDRESS || "address";
 
@@ -24,6 +67,7 @@ async function main(): Promise<void> {
     host: host,
     hostname: host,
     username: username,
+    password: password,
     port: port,
     reconnect: false
   };
@@ -37,14 +81,14 @@ async function main(): Promise<void> {
     onError: (context: EventContext) => {
       const senderError = context.sender && context.sender.error;
       if (senderError) {
-        console.log("[%s] An error occurred for sender '%s': %O.",
+        console.log(">>>>> [%s] An error occurred for sender '%s': %O.",
           connection.id, senderName, senderError);
       }
     },
     onSessionError: (context: EventContext) => {
       const sessionError = context.session && context.session.error;
       if (sessionError) {
-        console.log("[%s] An error occurred for session of sender '%s': %O.",
+        console.log(">>>>> [%s] An error occurred for session of sender '%s': %O.",
           connection.id, senderName, sessionError);
       }
     }
@@ -58,7 +102,7 @@ async function main(): Promise<void> {
   };
 
   const delivery: Delivery = await sender.send(message);
-  console.log(delivery);
+  console.log(">>>>>[%s] Delivery id: ", connection.id, delivery.id);
 
   await sender.close();
   await connection.close();
@@ -68,17 +112,19 @@ main().catch((err) => console.log(err));
 ```
 
 ### Receiving a message
+- Running the example from terminal: `> ts-node ./examples/receive.ts`.
 
+**NOTE:** If you are running the sample with `.env` config file, then please run the sample from the directory that contains `.env` config file. 
 ```ts
 import {
-  Connection, Receiver, EventContext, ConnectionOptions, ReceiverOptions, delay
+  Connection, Receiver, EventContext, ConnectionOptions, ReceiverOptions, delay, ReceiverEvents
 } from "rhea-promise";
-
 import * as dotenv from "dotenv"; // Optional for loading environment configuration from a .env (config) file
 dotenv.config();
 
 const host = process.env.AMQP_HOST || "host";
-const username = process.env.AMQP_USERNAME || "username";
+const username = process.env.AMQP_USERNAME || "sharedAccessKeyName";
+const password = process.env.AMQP_PASSWORD || "sharedAccessKeyValue";
 const port = parseInt(process.env.AMQP_PORT || "5671");
 const receiverAddress = process.env.RECEIVER_ADDRESS || "address";
 
@@ -88,6 +134,7 @@ async function main(): Promise<void> {
     host: host,
     hostname: host,
     username: username,
+    password: password,
     port: port,
     reconnect: false
   };
@@ -95,23 +142,13 @@ async function main(): Promise<void> {
   const receiverName = "receiver-1";
   const receiverOptions: ReceiverOptions = {
     name: receiverName,
-    target: {
+    source: {
       address: receiverAddress
-    },
-    onMessage: (context: EventContext) => {
-      console.log("Received message: %O", context.message);
-    },
-    onError: (context: EventContext) => {
-      const receiverError = context.receiver && context.receiver.error;
-      if (receiverError) {
-        console.log("[%s] An error occurred for receiver '%s': %O.",
-          connection.id, receiverName, receiverError);
-      }
     },
     onSessionError: (context: EventContext) => {
       const sessionError = context.session && context.session.error;
       if (sessionError) {
-        console.log("[%s] An error occurred for session of receiver '%s': %O.",
+        console.log(">>>>> [%s] An error occurred for session of receiver '%s': %O.",
           connection.id, receiverName, sessionError);
       }
     }
@@ -119,6 +156,16 @@ async function main(): Promise<void> {
 
   await connection.open();
   const receiver: Receiver = await connection.createReceiver(receiverOptions);
+  receiver.on(ReceiverEvents.message, (context: EventContext) => {
+    console.log("Received message: %O", context.message);
+  });
+  receiver.on(ReceiverEvents.receiverError, (context: EventContext) => {
+    const receiverError = context.receiver && context.receiver.error;
+    if (receiverError) {
+      console.log(">>>>> [%s] An error occurred for receiver '%s': %O.",
+        connection.id, receiverName, receiverError);
+    }
+  });
   // sleeping for 2 mins to let the receiver receive messages and then closing it.
   await delay(120000);
   await receiver.close();
@@ -126,5 +173,62 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => console.log(err));
+```
 
+## Design 
+The library provides an easy to use promisfied API for creating connection, session, sender and 
+receiver links. One can provide event handlers as optional properties while creating entities or 
+can use the standard event emitter pattern to add listeners to the created entities.
+
+For implementing the Event Emitter pattern, we considered different approaches like:
+**extending rhea's objects** (Connection, Session, Sender, Receiver). However, this has an overhead 
+of ensuring that there are no naming conflicts in the method names. Selecting different names for 
+operations like `open` and `close` would add more confusion.
+
+Hence we settled with, **wrapping rhea's objects** under our own equivalent objects. To ensure that 
+user's can efficiently use different event emitter methods like `.once()`, `.on()`,
+`.prependListeners()`, etc. we decided to add listeners to rhea's objects 
+(connection, session, sender, receiver) for all the possible events that those objects can 
+emit. From those listeners, equivalent `rhea-promise` objects emit the same events with same 
+arguments as one would expect from an event emitted by one of the above mentioned objects from 
+`rhea`. User's can add/remove listeners to `rhea-promise` objects. Whenever an event is emitted 
+from an object from `rhea`, it's equivalent counterpart in `rhea-romise` would emit the same event.
+
+`rhea` deals little differently with *_error and *_close events. If an event listener is **not added** 
+to a link (sender, receiver) then it will emit the `sender_error, sender_close, receiver_error, receiver_close` 
+events to the `session` object that the `link` belongs to. If there are no event listeners 
+for thoe events at the `session` level then, it emits those events to the `connection` object. Still 
+if it could not find listeners for those events then the events are bubbled up to the `container` 
+object and eventually those events are transformed into `error` events, if there were no event 
+listeners for those events at the container level. 
+
+It does the same thing for `session_error, session_close` events. Events are bubbled up to the 
+`connection`  and `container` objects and eventually emitted as `error` events if no listeners 
+were found for those events at the respective levels.
+
+This behavior of `rhea` will not be reciprocated by `rhea-promise` since, it adds event listeners 
+to each of the equivalent rhea objects. Thus *_error and *_close events will never bubble up. 
+If you do not add event listeners for those objects while using `rhea-promise` then you will not 
+know why an `error` or a `close` event occurred. So please make sure that right kind of event 
+listeners are added to the right objects. This enforces good practices to be followed while using 
+the event emitter pattern.
+
+
+## Building the library
+- Clone the repo
+```
+git clone https://github.com/amqp/rhea-promise.git
+```
+- Install typescript, ts-node globally
+```
+npm i -g typescript
+npm i -g ts-node
+```
+- NPM install from the root of the package
+```
+npm i
+```
+- Build the project
+```
+npm run build
 ```

--- a/examples/send.ts
+++ b/examples/send.ts
@@ -1,3 +1,5 @@
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
 import {
   Connection, Sender, EventContext, Message, ConnectionOptions, Delivery, SenderOptions
@@ -7,7 +9,8 @@ import * as dotenv from "dotenv"; // Optional for loading environment configurat
 dotenv.config();
 
 const host = process.env.AMQP_HOST || "host";
-const username = process.env.AMQP_USERNAME || "username";
+const username = process.env.AMQP_USERNAME || "sharedAccessKeyName";
+const password = process.env.AMQP_PASSWORD || "sharedAccessKeyValue";
 const port = parseInt(process.env.AMQP_PORT || "5671");
 const senderAddress = process.env.SENDER_ADDRESS || "address";
 
@@ -17,6 +20,7 @@ async function main(): Promise<void> {
     host: host,
     hostname: host,
     username: username,
+    password: password,
     port: port,
     reconnect: false
   };
@@ -30,14 +34,14 @@ async function main(): Promise<void> {
     onError: (context: EventContext) => {
       const senderError = context.sender && context.sender.error;
       if (senderError) {
-        console.log("[%s] An error occurred for sender '%s': %O.",
+        console.log(">>>>> [%s] An error occurred for sender '%s': %O.",
           connection.id, senderName, senderError);
       }
     },
     onSessionError: (context: EventContext) => {
       const sessionError = context.session && context.session.error;
       if (sessionError) {
-        console.log("[%s] An error occurred for session of sender '%s': %O.",
+        console.log(">>>>> [%s] An error occurred for session of sender '%s': %O.",
           connection.id, senderName, sessionError);
       }
     }
@@ -51,7 +55,7 @@ async function main(): Promise<void> {
   };
 
   const delivery: Delivery = await sender.send(message);
-  console.log(delivery);
+  console.log(">>>>>[%s] Delivery id: ", connection.id, delivery.id);
 
   await sender.close();
   await connection.close();

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -1,25 +1,18 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-import * as rhea from "rhea";
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 import * as log from "./log";
 import { Session } from "./session";
 import { Sender, SenderOptions } from "./sender";
 import { Receiver, ReceiverOptions } from "./receiver";
-import { ConnectionEvents, SessionEvents } from "rhea";
+import {
+  ConnectionEvents, SessionEvents, SenderEvents, ReceiverEvents, OnAmqpEvent, create_connection,
+  ConnectionOptions as RheaConnectionOptions, Connection as RheaConnection, EventContext, ConnectionError
+} from "rhea";
 import { defaultOperationTimeoutInSeconds } from "./util/constants";
 import { Func } from "./util/utils";
+import { EventEmitter } from "events";
+import { PeerCertificate } from "tls";
+import { Socket } from "net";
 
 /**
  * Describes the options that can be provided while creating an AMQP sender. One can also provide a
@@ -41,8 +34,9 @@ export interface ReceiverOptionsWithSession extends ReceiverOptions {
 
 /**
  * Describes the options that can be provided while creating an AMQP connection.
+ * @interface ConnectionOptions
  */
-export interface ConnectionOptions extends rhea.ConnectionOptions {
+export interface ConnectionOptions extends RheaConnectionOptions {
   /**
    * @property {number} [operationTimeoutInSeconds] - The duration in which the promise should
    * complete (resolve/reject). If it is not completed, then the Promise will be rejected after
@@ -73,33 +67,43 @@ export interface ReqResLink {
 }
 
 /**
+ * Describes the event listeners that can be added to the Connection.
+ * @interface Connection
+ */
+export declare interface Connection {
+  on(event: ConnectionEvents, listener: OnAmqpEvent): this;
+}
+
+/**
  * Descibes the AQMP Connection.
  * @class Connection
  */
-export class Connection {
+export class Connection extends EventEmitter {
   /**
    * @property {ConnectionOptions} [options] Options that can be provided while creating the
    * connection.
    */
   options?: ConnectionOptions;
   /**
-   * @property {rhea.Connection} _connection The connection object from rhea library.
+   * @property {RheaConnection} _connection The connection object from rhea library.
    * @private
    */
-  private _connection: rhea.Connection;
+  private _connection: RheaConnection;
 
   /**
    * Creates an instance of the Connection object.
    * @constructor
-   * @param {rhea.Connection} _connection The connection object from rhea library.
+   * @param {Connection} _connection The connection object from rhea library.
    */
   constructor(options?: ConnectionOptions) {
     if (!options) options = {};
     if (options.operationTimeoutInSeconds == undefined) {
       options.operationTimeoutInSeconds = defaultOperationTimeoutInSeconds;
     }
+    super();
     this.options = options;
-    this._connection = rhea.create_connection(options);
+    this._connection = create_connection(options);
+    this._initializeEventListeners();
   }
 
   /**
@@ -121,18 +125,18 @@ export class Connection {
     return new Promise((resolve, reject) => {
       if (!this.isOpen()) {
 
-        let onOpen: Func<rhea.EventContext, void>;
-        let onClose: Func<rhea.EventContext, void>;
+        let onOpen: Func<EventContext, void>;
+        let onClose: Func<EventContext, void>;
         let waitTimer: any;
 
         const removeListeners: Function = () => {
           clearTimeout(waitTimer);
-          this._connection.removeListener(ConnectionEvents.connectionOpen, onOpen);
-          this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
-          this._connection.removeListener(ConnectionEvents.disconnected, onClose);
+          this.removeListener(ConnectionEvents.connectionOpen, onOpen);
+          this.removeListener(ConnectionEvents.connectionClose, onClose);
+          this.removeListener(ConnectionEvents.disconnected, onClose);
         };
 
-        onOpen = (context: rhea.EventContext) => {
+        onOpen = (context: EventContext) => {
           removeListeners();
           setTimeout(() => {
             log.connection("[%s] Resolving the promise with amqp connection.", this.id);
@@ -140,7 +144,7 @@ export class Connection {
           });
         };
 
-        onClose = (context: rhea.EventContext) => {
+        onClose = (context: EventContext) => {
           removeListeners();
           const err = context.error || context.connection.error;
           log.error("[%s] Error occurred while establishing amqp connection: %O",
@@ -155,10 +159,11 @@ export class Connection {
           reject(new Error(msg));
         };
 
-        this._connection.once(ConnectionEvents.connectionOpen, onOpen);
-        this._connection.once(ConnectionEvents.connectionClose, onClose);
-        this._connection.once(ConnectionEvents.disconnected, onClose);
+        this.once(ConnectionEvents.connectionOpen, onOpen);
+        this.once(ConnectionEvents.connectionClose, onClose);
+        this.once(ConnectionEvents.disconnected, onClose);
         waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
+        log.connection("[%s] Trying to create a new amqp connection.", this.id);
         this._connection.connect();
       } else {
         resolve(this);
@@ -178,16 +183,16 @@ export class Connection {
     return new Promise<void>((resolve, reject) => {
       log.error("[%s] The connection is open ? -> %s", this.id, this.isOpen());
       if (this.isOpen()) {
-        let onClose: Func<rhea.EventContext, void>;
-        let onError: Func<rhea.EventContext, void>;
+        let onClose: Func<EventContext, void>;
+        let onError: Func<EventContext, void>;
         let waitTimer: any;
         const removeListeners = () => {
           clearTimeout(waitTimer);
-          this._connection.removeListener(ConnectionEvents.connectionError, onError);
-          this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
+          this.removeListener(ConnectionEvents.connectionError, onError);
+          this.removeListener(ConnectionEvents.connectionClose, onClose);
         };
 
-        onClose = (context: rhea.EventContext) => {
+        onClose = (context: EventContext) => {
           removeListeners();
           setTimeout(() => {
             log.connection("[%s] Resolving the promise as the connection has been successfully closed.",
@@ -196,7 +201,7 @@ export class Connection {
           });
         };
 
-        onError = (context: rhea.EventContext) => {
+        onError = (context: EventContext) => {
           removeListeners();
           log.error("[%s] Error occurred while closing amqp connection: %O.",
             this.id, context.connection.error);
@@ -210,8 +215,8 @@ export class Connection {
           reject(new Error(msg));
         };
 
-        this._connection.once(ConnectionEvents.connectionClose, onClose);
-        this._connection.once(ConnectionEvents.connectionError, onError);
+        this.once(ConnectionEvents.connectionClose, onClose);
+        this.once(ConnectionEvents.connectionError, onError);
         waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
         this._connection.close();
       } else {
@@ -230,6 +235,38 @@ export class Connection {
       result = true;
     }
     return result;
+  }
+
+  /**
+   * Determines whether the remote end of the connection is open.
+   * @returns {boolean} result `true` - is open; `false` otherwise.
+   */
+  isRemoteOpen(): boolean {
+    return this._connection.is_remote_open();
+  }
+
+  /**
+   * Gets the connection error if present.
+   * @returns {ConnectionError | undefined} ConnectionError | undefined
+   */
+  getError(): ConnectionError | undefined {
+    return this._connection.get_error();
+  }
+
+  /**
+   * Gets the peer certificate if present.
+   * @returns {PeerCertificate | undefined} PeerCertificate | undefined
+   */
+  getPeerCertificate(): PeerCertificate | undefined {
+    return this._connection.get_peer_certificate();
+  }
+
+  /**
+   * Gets the tls socket if present.
+   * @returns {Socket | undefined} Socket | undefined
+   */
+  getTlsSocket(): Socket | undefined {
+    return this._connection.get_tls_socket();
   }
 
   /**
@@ -252,8 +289,8 @@ export class Connection {
     return new Promise((resolve, reject) => {
       const rheaSession = this._connection.create_session();
       const session = new Session(this, rheaSession);
-      let onOpen: Func<rhea.EventContext, void>;
-      let onClose: Func<rhea.EventContext, void>;
+      let onOpen: Func<EventContext, void>;
+      let onClose: Func<EventContext, void>;
       let waitTimer: any;
 
       const removeListeners = () => {
@@ -262,7 +299,7 @@ export class Connection {
         rheaSession.removeListener(SessionEvents.sessionClose, onClose);
       };
 
-      onOpen = (context: rhea.EventContext) => {
+      onOpen = (context: EventContext) => {
         removeListeners();
         setTimeout(() => {
           log.connection("[%s] Resolving the promise with amqp session.", this.id);
@@ -270,7 +307,7 @@ export class Connection {
         });
       };
 
-      onClose = (context: rhea.EventContext) => {
+      onClose = (context: EventContext) => {
         removeListeners();
         log.error("[%s] Error occurred while establishing a session over amqp connection: %O.",
           this.id, context.session!.error);
@@ -349,23 +386,33 @@ export class Connection {
   }
 
   /**
-   * Registers the given handler for the specified event.
-   * @param {rhea.ConnectionEvents} event The event for which the handler needs to be registered.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be executed when the event
-   * occurs.
-   * @returns {void} void.
+   * Adds event listeners for the possible events that can occur on the connection object and
+   * re-emits the same event back with the received arguments from rhea's event emitter.
+   * @private
+   * @returns {void} void
    */
-  registerHandler(event: ConnectionEvents, handler: rhea.OnAmqpEvent): void {
-    this._connection.on(event, handler);
-  }
+  private _initializeEventListeners(): void {
+    for (const eventName in ConnectionEvents) {
+      this._connection.on(ConnectionEvents[eventName],
+        (...args) => this.emit(ConnectionEvents[eventName], ...args));
+    }
 
-  /**
-   * Removes the given handler for the specified event.
-   * @param {rhea.ConnectionEvents} event The event for which the handler needs to be removed.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be removed.
-   * @returns {void} void.
-   */
-  removeHandler(event: ConnectionEvents, handler: rhea.OnAmqpEvent): void {
-    this._connection.removeListener(event, handler);
+    // Add event handlers for *_error and *_close events that can be propogated to the connection
+    // object, if they are not handled at their level. * denotes - Sender, Receiver, Session
+    // Sender
+    this._connection.on(SenderEvents.senderError,
+      (...args) => this.emit(SenderEvents.senderError, ...args));
+    this._connection.on(SenderEvents.senderClose,
+      (...args) => this.emit(SenderEvents.senderClose, ...args));
+    // Receiver
+    this._connection.on(ReceiverEvents.receiverError,
+      (...args) => this.emit(ReceiverEvents.receiverError, ...args));
+    this._connection.on(ReceiverEvents.receiverClose,
+      (...args) => this.emit(ReceiverEvents.receiverClose, ...args));
+    // Session
+    this._connection.on(SessionEvents.sessionError,
+      (...args) => this.emit(SessionEvents.sessionError, ...args));
+    this._connection.on(SessionEvents.sessionClose,
+      (...args) => this.emit(SessionEvents.sessionClose, ...args));
   }
 }

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -1,18 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache License. See License in the project root for license information.
+
+import { EventEmitter } from "events";
+import { PeerCertificate } from "tls";
+import { Socket } from "net";
 import * as log from "./log";
 import { Session } from "./session";
 import { Sender, SenderOptions } from "./sender";
 import { Receiver, ReceiverOptions } from "./receiver";
+import { Container } from "./container";
+import { defaultOperationTimeoutInSeconds } from "./util/constants";
+import { Func } from "./util/utils";
 import {
   ConnectionEvents, SessionEvents, SenderEvents, ReceiverEvents, OnAmqpEvent, create_connection,
   ConnectionOptions as RheaConnectionOptions, Connection as RheaConnection, EventContext, ConnectionError
 } from "rhea";
-import { defaultOperationTimeoutInSeconds } from "./util/constants";
-import { Func } from "./util/utils";
-import { EventEmitter } from "events";
-import { PeerCertificate } from "tls";
-import { Socket } from "net";
 
 /**
  * Describes the options that can be provided while creating an AMQP sender. One can also provide a
@@ -85,6 +87,10 @@ export class Connection extends EventEmitter {
    */
   options?: ConnectionOptions;
   /**
+   * @property {Container} container The underlying Container instance on which the connection exists.
+   */
+  readonly container: Container;
+  /**
    * @property {RheaConnection} _connection The connection object from rhea library.
    * @private
    */
@@ -103,6 +109,7 @@ export class Connection extends EventEmitter {
     super();
     this.options = options;
     this._connection = create_connection(options);
+    this.container = Container.copyFromContainerInstance(this._connection.container);
     this._initializeEventListeners();
   }
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -131,9 +131,9 @@ export class Connection extends EventEmitter {
 
         const removeListeners: Function = () => {
           clearTimeout(waitTimer);
-          this.removeListener(ConnectionEvents.connectionOpen, onOpen);
-          this.removeListener(ConnectionEvents.connectionClose, onClose);
-          this.removeListener(ConnectionEvents.disconnected, onClose);
+          this._connection.removeListener(ConnectionEvents.connectionOpen, onOpen);
+          this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
+          this._connection.removeListener(ConnectionEvents.disconnected, onClose);
         };
 
         onOpen = (context: EventContext) => {
@@ -159,9 +159,10 @@ export class Connection extends EventEmitter {
           reject(new Error(msg));
         };
 
-        this.once(ConnectionEvents.connectionOpen, onOpen);
-        this.once(ConnectionEvents.connectionClose, onClose);
-        this.once(ConnectionEvents.disconnected, onClose);
+        // listeners that we add for completing the operation are added directly to rhea's objects.
+        this._connection.once(ConnectionEvents.connectionOpen, onOpen);
+        this._connection.once(ConnectionEvents.connectionClose, onClose);
+        this._connection.once(ConnectionEvents.disconnected, onClose);
         waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
         log.connection("[%s] Trying to create a new amqp connection.", this.id);
         this._connection.connect();
@@ -188,8 +189,8 @@ export class Connection extends EventEmitter {
         let waitTimer: any;
         const removeListeners = () => {
           clearTimeout(waitTimer);
-          this.removeListener(ConnectionEvents.connectionError, onError);
-          this.removeListener(ConnectionEvents.connectionClose, onClose);
+          this._connection.removeListener(ConnectionEvents.connectionError, onError);
+          this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
         };
 
         onClose = (context: EventContext) => {
@@ -215,8 +216,9 @@ export class Connection extends EventEmitter {
           reject(new Error(msg));
         };
 
-        this.once(ConnectionEvents.connectionClose, onClose);
-        this.once(ConnectionEvents.connectionError, onError);
+        // listeners that we add for completing the operation are added directly to rhea's objects.
+        this._connection.once(ConnectionEvents.connectionClose, onClose);
+        this._connection.once(ConnectionEvents.connectionError, onError);
         waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
         this._connection.close();
       } else {
@@ -321,6 +323,7 @@ export class Connection extends EventEmitter {
         reject(new Error(msg));
       };
 
+      // listeners that we add for completing the operation are added directly to rhea's objects.
       rheaSession.once(SessionEvents.sessionOpen, onOpen);
       rheaSession.once(SessionEvents.sessionClose, onClose);
       log.connection("[%s] Calling amqp session.begin().", this.id);

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -13,7 +13,8 @@ import { defaultOperationTimeoutInSeconds } from "./util/constants";
 import { Func } from "./util/utils";
 import {
   ConnectionEvents, SessionEvents, SenderEvents, ReceiverEvents, OnAmqpEvent, create_connection,
-  ConnectionOptions as RheaConnectionOptions, Connection as RheaConnection, EventContext, ConnectionError
+  ConnectionOptions as RheaConnectionOptions, Connection as RheaConnection, EventContext,
+  ConnectionError, Dictionary, AmqpError
 } from "rhea";
 
 /**
@@ -122,11 +123,59 @@ export class Connection extends EventEmitter {
   }
 
   /**
+   * @property {Dictionary<any> | undefined} [properties] Provides the connection properties.
+   * @readonly
+   */
+  get properties(): Dictionary<any> | undefined {
+    return this._connection.properties;
+  }
+
+  /**
+   * @property {number | undefined} [maxFrameSize] Provides the max frame size.
+   * @readonly
+   */
+  get maxFrameSize(): number | undefined {
+    return this._connection.max_frame_size;
+  }
+
+  /**
+   * @property {number | undefined} [idleTimeout] Provides the idle timeout for the connection.
+   * @readonly
+   */
+  get idleTimeout(): number | undefined {
+    return this._connection.idle_time_out;
+  }
+
+  /**
+   * @property {number | undefined} [channelMax] Provides the maximum number of channels supported.
+   * @readonly
+   */
+  get channelMax(): number | undefined {
+    return this._connection.channel_max;
+  }
+
+  /**
+   * @property {AmqpError | Error | undefined} [error] Provides the last error that occurred on the
+   * connection.
+   */
+  get error(): AmqpError | Error | undefined {
+    return this._connection.error;
+  }
+
+  /**
+   * Removes the provided session from the internal map.
+   * @param {Session} session The session to be removed.
+   */
+  removeSession(session: Session): void {
+    return session.remove();
+  }
+
+  /**
    * Creates a new amqp connection.
    * @return {Promise<Connection>} Promise<Connection>
    * - **Resolves** the promise with the Connection object when rhea emits the "connection_open" event.
-   * - **Rejects** the promise with an AmqpError when rhea emits the "connection_close" event while trying
-   * to establish an amqp connection.
+   * - **Rejects** the promise with an AmqpError when rhea emits the "connection_close" event
+   * while trying to establish an amqp connection.
    */
   open(): Promise<Connection> {
     return new Promise((resolve, reject) => {

--- a/lib/container.ts
+++ b/lib/container.ts
@@ -2,7 +2,8 @@
 // Licensed under the Apache License. See License in the project root for license information.
 
 import {
-  Container as RheaContainer, ContainerOptions as ContainerOptionsBase, create_container, Filter, Types, MessageUtil, Sasl
+  Container as RheaContainer, ContainerOptions as ContainerOptionsBase, create_container,
+  Filter, Types, MessageUtil, Sasl
 } from "rhea";
 import { EventEmitter } from "events";
 import { ConnectionOptions, Connection } from './connection';

--- a/lib/container.ts
+++ b/lib/container.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
+
+import {
+  Container as RheaContainer, ContainerOptions as ContainerOptionsBase, create_container, Filter, Types, MessageUtil, Sasl
+} from "rhea";
+import { EventEmitter } from "events";
+import { ConnectionOptions, Connection } from './connection';
+import { TlsOptions, Server as TlsServer, ConnectionOptions as TlsConnectionOptions } from "tls";
+import { ListenOptions, Server, Socket } from "net";
+
+/**
+ * Descibes the options that can be provided while creating the Container.
+ * @interface ContainerOptions
+ */
+export interface ContainerOptions extends ContainerOptionsBase {
+  createdInstance?: RheaContainer;
+}
+
+/**
+ * An AMQP container from which outgoing connections can be made and/or
+ * to which incoming connections can be accepted.
+ * @class Container
+ */
+export class Container extends EventEmitter {
+  /**
+   * @property {options} [ContainerOptions] Container options.
+   */
+  options?: ContainerOptions;
+  /**
+   * @property {RheaContainer} _container The underlying container object from rhea.
+   * @private
+   */
+  private _container: RheaContainer;
+
+  constructor(options?: ContainerOptions) {
+    if (!options) options = {};
+    super();
+    if (options.createdInstance) {
+      this._container = options.createdInstance;
+      delete options.createdInstance;
+    } else {
+      this._container = create_container(options);
+    }
+
+    this.options = this._container.options;
+  }
+
+  get id(): string {
+    return this._container.id;
+  }
+
+  get filter(): Filter {
+    return this._container.filter;
+  }
+
+  get types(): Types {
+    return this._container.types;
+  }
+
+  get message(): MessageUtil {
+    return this._container.message;
+  }
+
+  get sasl(): Sasl {
+    return this._container.sasl;
+  }
+
+  get saslServerMechanisms(): any {
+    return this._container.sasl_server_mechanisms;
+  }
+
+  createConnection(options?: ConnectionOptions): Connection {
+    return new Connection(options);
+  }
+
+  listen(options: ListenOptions | TlsOptions): Server | TlsServer {
+    return this._container.listen(options);
+  }
+
+  generateUUid(): string {
+    return this._container.generate_uuid();
+  }
+
+  stringToUuid(uuidString: string): Buffer {
+    return this._container.string_to_uuid(uuidString);
+  }
+
+  uuidToString(buffer: Buffer): string {
+    return this._container.uuid_to_string(buffer);
+  }
+
+  websocketAccept(socket: Socket, options: TlsConnectionOptions): void {
+    return this._container.websocket_accept(socket, options);
+  }
+
+  websocketConnect(impl: any): any {
+    return this._container.websocket_connect(impl);
+  }
+
+  static create(options?: ContainerOptionsBase): Container {
+    return new Container(options);
+  }
+
+  static copyFromContainerInstance(instance: RheaContainer): Container {
+    return new Container({ createdInstance: instance });
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,13 +3,16 @@
 
 export {
   Delivery, Message, OnAmqpEvent, MessageProperties, MessageHeader, EventContext,
-  ConnectionOptions, AmqpError, Dictionary, types, message, filter, Filter, MessageUtil,
+  ConnectionOptions as ConnectionOptionsBase, AmqpError, Dictionary, types, message, filter, Filter, MessageUtil,
   uuid_to_string, generate_uuid, string_to_uuid, LinkError, ProtocolError, LinkOptions,
   DeliveryAnnotations, MessageAnnotations, ReceiverEvents, SenderEvents, ConnectionEvents,
-  SessionEvents
+  SessionEvents, ContainerOptions as ContainerOptionsBase, TerminusOptions, Types, Sasl,
 } from "rhea";
 
-export { Connection, ReqResLink } from "./connection";
+export { Container, ContainerOptions } from "./container";
+export {
+  Connection, ReqResLink, ConnectionOptions, ReceiverOptionsWithSession, SenderOptionsWithSession
+} from "./connection";
 export { Session } from "./session";
 export { Receiver, ReceiverOptions } from "./receiver";
 export { Sender, SenderOptions } from "./sender";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,16 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
 export {
   Delivery, Message, OnAmqpEvent, MessageProperties, MessageHeader, EventContext,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,10 +3,11 @@
 
 export {
   Delivery, Message, OnAmqpEvent, MessageProperties, MessageHeader, EventContext,
-  ConnectionOptions as ConnectionOptionsBase, AmqpError, Dictionary, types, message, filter, Filter, MessageUtil,
+  ConnectionOptions as ConnectionOptionsBase, AmqpError, Dictionary, types, message, filter, Filter,
   uuid_to_string, generate_uuid, string_to_uuid, LinkError, ProtocolError, LinkOptions,
   DeliveryAnnotations, MessageAnnotations, ReceiverEvents, SenderEvents, ConnectionEvents,
   SessionEvents, ContainerOptions as ContainerOptionsBase, TerminusOptions, Types, Sasl,
+  EndpointOptions, MessageUtil, TypeError, SimpleError, Source, ConnectionError
 } from "rhea";
 
 export { Container, ContainerOptions } from "./container";

--- a/lib/link.ts
+++ b/lib/link.ts
@@ -1,0 +1,279 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
+
+import * as log from "./log";
+import { link, LinkOptions, AmqpError, Dictionary, Source, TerminusOptions, EventContext, SenderEvents, ReceiverEvents } from "rhea";
+import { EventEmitter } from "events";
+import { Session } from "./session";
+import { Connection } from "./connection";
+import { Func } from './util/utils';
+
+export enum LinkType {
+  sender = "sender",
+  receiver = "receiver"
+}
+
+export abstract class Link extends EventEmitter {
+  linkOptions?: LinkOptions;
+  type: LinkType;
+  protected _link: link;
+  protected _session: Session;
+  constructor(type: LinkType, session: Session, link: link, options?: LinkOptions) {
+    super();
+    this.type = type;
+    this._session = session;
+    this._link = link;
+    this.linkOptions = options;
+    this._initializeEventListeners();
+  }
+
+  get name(): string {
+    return this._link.name;
+  }
+
+  get error(): AmqpError | Error | undefined {
+    return this._link.error;
+  }
+
+  get properties(): Dictionary<any> {
+    return this._link.properties;
+  }
+
+  get sendSettleMode(): 0 | 1 | 2 {
+    return this._link.snd_settle_mode;
+  }
+
+  get receiveSettleMode(): 0 | 1 {
+    return this._link.rcv_settle_mode;
+  }
+
+  get source(): Source {
+    return this._link.source;
+  }
+
+  set source(fields: Source) {
+    this._link.set_source(fields);
+  }
+
+  get target(): TerminusOptions {
+    return this._link.target;
+  }
+
+  set target(fields: TerminusOptions) {
+    this._link.set_source(fields);
+  }
+
+  get maxMessageSize(): number {
+    return this._link.max_message_size;
+  }
+
+  get offeredCapabilities(): string | string[] {
+    return this._link.offered_capabilities;
+  }
+
+  get desiredCapabilities(): string | string[] {
+    return this._link.desired_capabilities;
+  }
+
+  get address(): string {
+    return this.source.address;
+  }
+
+  get credit(): number {
+    return (this._link as any).credit;
+  }
+
+  get session(): Session {
+    return this._session;
+  }
+
+  get connection(): Connection {
+    return this._session.connection;
+  }
+
+  /**
+   * Determines whether the sender link and its underlying session is open.
+   * @returns {boolean} `true` open. `false` closed.
+   */
+  isOpen(): boolean {
+    let result = false;
+    if (this._session.isOpen() && this._link.is_open()) {
+      result = true;
+    }
+    return result;
+  }
+
+  /**
+   * Determines whether the remote end of the link is open.
+   * @return {boolean} boolean `true` - is open; `false` otherwise.
+   */
+  isRemoteOpen(): boolean {
+    return this._link.is_remote_open();
+  }
+
+  /**
+   * Determines whether the link has credit.
+   * @return {boolean} boolean `true` - has credit; `false` otherwise.
+   */
+  hasCredit(): boolean {
+    return this._link.has_credit();
+  }
+
+  /**
+   * Determines whether the link is a sender.
+   * @return {boolean} boolean `true` - sender; `false` otherwise.
+   */
+  isSender(): boolean {
+    return this._link.is_sender();
+  }
+
+  /**
+   * Determines whether the link is a receiver.
+   * @return {boolean} boolean `true` - receiver; `false` otherwise.
+   */
+  isReceiver(): boolean {
+    return this._link.is_receiver();
+  }
+
+  /**
+   * Determines whether both local and remote endpoint for link or it's underlying session
+   * or it's underlying connection are closed.
+   * Within the "sender_close", "session_close" event handler, if this
+   * method returns `false` it means that the local end is still open. It can be useful to
+   * determine whether the close was initiated locally under such circumstances.
+   *
+   * @returns {boolean} `true` if closed, `false` otherwise.
+   */
+  isClosed(): boolean {
+    return this._link.is_closed();
+  }
+
+  /**
+   * Determines whether both local and remote endpoint for just the link itself are closed.
+   * Within the "sender_close" event handler, if this method returns `false` it
+   * means that the local end is still open. It can be useful to determine whether the close
+   * was initiated locally under such circumstances.
+   *
+   * @returns {boolean} `true` - closed, `false` otherwise.
+   */
+  isItselfClosed(): boolean {
+    return this._link.is_itself_closed();
+  }
+
+  /**
+   * Determines whether both local and remote endpoint for session or it's underlying
+   * connection are closed.
+   *
+   * Within the "session_close" event handler, if this method returns `false` it means that
+   * the local end is still open. It can be useful to determine whether the close
+   * was initiated locally under such circumstances.
+   *
+   * @returns {boolean} `true` - closed, `false` otherwise.
+   */
+  isSessionClosed(): boolean {
+    return this._session.isClosed();
+  }
+
+  /**
+   * Determines whether both local and remote endpoint for just the session itself are closed.
+   * Within the "session_close" event handler, if this method returns `false` it means that
+   * the local end is still open. It can be useful to determine whether the close
+   * was initiated locally under such circumstances.
+   *
+   * @returns {boolean} `true` - closed, `false` otherwise.
+   */
+  isSessionItselfClosed(): boolean {
+    return this._session.isItselfClosed();
+  }
+
+  /**
+   * Removes the sender and it's underlying session from the internal map.
+   * @returns {void} void
+   */
+  remove(): void {
+    if (this._link) {
+      this._link.remove();
+    }
+    if (this._session) {
+      this._session.remove();
+    }
+  }
+
+  /**
+   * Closes the amqp link.
+   * @return {Promise<void>} Promise<void>
+   * - **Resolves** the promise when rhea emits the "sender_close" | "receiver_close" event.
+   * - **Rejects** the promise with an AmqpError when rhea emits the
+   * "sender_error" | "receiver_error" event while trying to close the amqp link.
+   */
+  async close(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      log.error("[%s] The %s is open ? -> %s", this.connection.id, this.type, this.isOpen());
+      if (this.isOpen()) {
+        const errorEvent = this.type === LinkType.sender
+          ? SenderEvents.senderError
+          : ReceiverEvents.receiverError;
+        const closeEvent = this.type === LinkType.sender
+          ? SenderEvents.senderClose
+          : ReceiverEvents.receiverClose;
+        let onError: Func<EventContext, void>;
+        let onClose: Func<EventContext, void>;
+        let waitTimer: any;
+
+        const removeListeners = () => {
+          clearTimeout(waitTimer);
+          this.removeListener(errorEvent, onError);
+          this.removeListener(closeEvent, onClose);
+        };
+
+        onClose = (context: EventContext) => {
+          removeListeners();
+          setTimeout(() => {
+            log[this.type]("[%s] Resolving the promise as the amqp %s has been closed.",
+              this.connection.id, this.type);
+            resolve();
+          });
+        };
+
+        onError = (context: EventContext) => {
+          removeListeners();
+          log.error("[%s] Error occurred while closing amqp %s: %O.",
+            this.connection.id, this.type, context.session!.error);
+          reject(context.session!.error);
+        };
+
+        const actionAfterTimeout = () => {
+          removeListeners();
+          const msg: string = `Unable to close the amqp %s ${this.name} due to operation timeout.`;
+          log.error("[%s] %s", this.connection.id, this.type, msg);
+          reject(new Error(msg));
+        };
+
+        this.once(closeEvent, onClose);
+        this.once(errorEvent, onError);
+        waitTimer = setTimeout(actionAfterTimeout,
+          this.connection.options!.operationTimeoutInSeconds! * 1000);
+        this._link.close();
+      } else {
+        resolve();
+      }
+    });
+    log[this.type]("[%s] %s has been closed, now closing it's session.",
+      this.connection.id, this.type);
+    return await this._session.close();
+  }
+
+  /**
+   * Adds event listeners for the possible events that can occur on the link object and
+   * re-emits the same event back with the received arguments from rhea's event emitter.
+   * @private
+   * @returns {void} void
+   */
+  private _initializeEventListeners(): void {
+    const events = this.type === LinkType.sender ? SenderEvents : ReceiverEvents;
+    for (const eventName in events) {
+      this._link.on(events[eventName],
+        (...args) => this.emit(events[eventName], ...args));
+    }
+  }
+}

--- a/lib/link.ts
+++ b/lib/link.ts
@@ -222,8 +222,8 @@ export abstract class Link extends EventEmitter {
 
         const removeListeners = () => {
           clearTimeout(waitTimer);
-          this.removeListener(errorEvent, onError);
-          this.removeListener(closeEvent, onClose);
+          this._link.removeListener(errorEvent, onError);
+          this._link.removeListener(closeEvent, onClose);
         };
 
         onClose = (context: EventContext) => {
@@ -249,8 +249,9 @@ export abstract class Link extends EventEmitter {
           reject(new Error(msg));
         };
 
-        this.once(closeEvent, onClose);
-        this.once(errorEvent, onError);
+        // listeners that we add for completing the operation are added directly to rhea's objects.
+        this._link.once(closeEvent, onClose);
+        this._link.once(errorEvent, onError);
         waitTimer = setTimeout(actionAfterTimeout,
           this.connection.options!.operationTimeoutInSeconds! * 1000);
         this._link.close();

--- a/lib/link.ts
+++ b/lib/link.ts
@@ -187,11 +187,14 @@ export abstract class Link extends EventEmitter {
   }
 
   /**
-   * Removes the sender and it's underlying session from the internal map.
+   * Removes the sender/receiver and it's underlying session from the internal map.
    * @returns {void} void
    */
   remove(): void {
     if (this._link) {
+      // Remove our listeners and listeners from rhea's link object.
+      this.removeAllListeners();
+      this._link.removeAllListeners();
       this._link.remove();
     }
     if (this._session) {

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -1,16 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
 import * as debugModule from "debug";
 /**

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -4,6 +4,11 @@
 import * as debugModule from "debug";
 /**
  * @ignore
+ * log statements for container
+ */
+export const container = debugModule("rhea-promise:container");
+/**
+ * @ignore
  * log statements for connection
  */
 export const connection = debugModule("rhea-promise:connection");

--- a/lib/receiver.ts
+++ b/lib/receiver.ts
@@ -1,23 +1,13 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
 import * as rhea from "rhea";
-import * as log from "./log";
+
 import { Session } from "./session";
-import { Connection } from "./connection";
-import { ReceiverEvents } from "rhea";
-import { Func } from "./util/utils";
+
+import { ReceiverEvents, Receiver as RheaReceiver } from "rhea";
+
+import { Link, LinkType } from "./link";
 
 /**
  * Descibes the options that can be provided while creating an AMQP sender.
@@ -52,237 +42,31 @@ export interface ReceiverOptions extends rhea.ReceiverOptions {
 }
 
 /**
+ * Describes the event listeners that can be added to the Receiver.
+ * @interface Receiver
+ */
+export declare interface Receiver {
+  on(event: ReceiverEvents, listener: rhea.OnAmqpEvent): this;
+}
+
+/**
  * Describes the receiver that wraps the rhea receiver.
  * @class Receiver.
  */
-export class Receiver {
-  receiverOptions?: ReceiverOptions;
-  private _session: Session;
-  private _receiver: rhea.Receiver;
-
+export class Receiver extends Link {
   constructor(session: Session, receiver: rhea.Receiver, options?: ReceiverOptions) {
-    this._session = session;
-    this._receiver = receiver;
-    this.receiverOptions = options;
-  }
-
-  get name(): string {
-    return this._receiver.name;
-  }
-
-  get error(): rhea.AmqpError | Error | undefined {
-    return this._receiver.error;
-  }
-
-  get properties(): rhea.Dictionary<any> {
-    return this._receiver.properties;
-  }
-
-  get source(): rhea.Source {
-    return this._receiver.source;
-  }
-
-  get target(): rhea.TerminusOptions {
-    return this._receiver.target;
-  }
-
-  get address(): string {
-    return this.source.address;
-  }
-
-  get session(): Session {
-    return this._session;
-  }
-
-  get connection(): Connection {
-    return this._session.connection;
+    super(LinkType.receiver, session, receiver, options);
   }
 
   get drain(): boolean {
-    return this._receiver.drain;
+    return (this._link as RheaReceiver).drain;
   }
 
   addCredit(credit: number): void {
-    this._receiver.add_credit(credit);
+    (this._link as RheaReceiver).add_credit(credit);
   }
 
   setCreditWindow(creditWindow: number): void {
-    this._receiver.set_credit_window(creditWindow);
-  }
-  /**
-   * Determines whether the receiver link and its session is open.
-   * @returns {boolean} `true` open. `false` closed.
-   */
-  isOpen(): boolean {
-    let result = false;
-    if (this._session.isOpen() && this._receiver.is_open()) {
-      result = true;
-    }
-    return result;
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for link or it's underlying session
-   * or it's underlying connection are closed.
-   * Within the "receiver_close", "session_close" event handler, if this
-   * method returns `false` it means that the local end is still open. It can be useful to
-   * determine whether the close was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` if closed, `false` otherwise.
-   */
-  isClosed(): boolean {
-    return this._receiver.is_closed();
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for just the link itself are closed.
-   * Within the "receiver_close" event handler, if this method returns `false` it
-   * means that the local end is still open. It can be useful to determine whether the close
-   * was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` - closed, `false` otherwise.
-   */
-  isItselfClosed(): boolean {
-    return this._receiver.is_itself_closed();
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for session or it's underlying
-   * connection are closed.
-   *
-   * Within the "session_close" event handler, if this method returns `false` it means that
-   * the local end is still open. It can be useful to determine whether the close
-   * was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` - closed, `false` otherwise.
-   */
-  isSessionClosed(): boolean {
-    return this._session.isClosed();
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for just the session itself are closed.
-   * Within the "session_close" event handler, if this method returns `false` it means that
-   * the local end is still open. It can be useful to determine whether the close
-   * was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` - closed, `false` otherwise.
-   */
-  isSessionItselfClosed(): boolean {
-    return this._session.isItselfClosed();
-  }
-
-  /**
-   * Removes the receiver and it's underlying session from the internal map.
-   * @returns {void} void
-   */
-  remove(): void {
-    if (this._receiver) {
-      this._receiver.remove();
-    }
-    if (this._session) {
-      this._session.remove();
-    }
-  }
-
-  /**
-   * Closes the amqp receiver.
-   * @return {Promise<void>} Promise<void>
-   * - **Resolves** the promise when rhea emits the "receiver_close" event.
-   * - **Rejects** the promise with an AmqpError when rhea emits the
-   * "receiver_error" event while trying to close an amqp receiver.
-   */
-  close(): Promise<void> {
-    const receiverClose = new Promise<void>((resolve, reject) => {
-      log.error("[%s] The receiver is open ? -> %s", this.connection.id, this.isOpen());
-      if (this.isOpen()) {
-        let onError: Func<rhea.EventContext, void>;
-        let onClose: Func<rhea.EventContext, void>;
-        let waitTimer: any;
-
-        const removeListeners = () => {
-          clearTimeout(waitTimer);
-          this._receiver.removeListener(ReceiverEvents.receiverError, onError);
-          this._receiver.removeListener(ReceiverEvents.receiverClose, onClose);
-        };
-
-        onClose = (context: rhea.EventContext) => {
-          removeListeners();
-          setTimeout(() => {
-            log.receiver("[%s] Resolving the promise as the amqp receiver has been closed.",
-              this.connection.id);
-            resolve();
-          });
-        };
-
-        onError = (context: rhea.EventContext) => {
-          removeListeners();
-          log.error("[%s] Error occurred while closing amqp receiver. %O",
-            this.connection.id, context.session!.error);
-          reject(context.session!.error);
-        };
-
-        const actionAfterTimeout = () => {
-          removeListeners();
-          const msg: string = `Unable to close the amqp receiver ${this.name} due to operation timeout.`;
-          log.error("[%s] %s", this.connection.id, msg);
-          reject(new Error(msg));
-        };
-
-        this._receiver.once(ReceiverEvents.receiverClose, onClose);
-        this._receiver.once(ReceiverEvents.receiverError, onError);
-        waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
-        this._receiver.close();
-      } else {
-        resolve();
-      }
-    });
-
-    return receiverClose.then(() => {
-      log.receiver("[%s] receiver has been closed, now closing it's session.", this.connection.id);
-      return this._session.close();
-    });
-  }
-
-  /**
-   * Registers the given handler for the specified event.
-   * @param {rhea.ReceiverEvents} event The event for which the handler needs to be registered.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be executed when the event
-   * occurs
-   * @returns {void} void.
-   */
-  registerHandler(event: ReceiverEvents, handler: rhea.OnAmqpEvent): void {
-    this._receiver.on(event, handler);
-  }
-
-  /**
-   * Removes the given handler for the specified event.
-   * @param {rhea.ReceiverEvents} event The event for which the handler needs to be removed.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be removed.
-   * @returns {void} void.
-   */
-  removeHandler(event: ReceiverEvents, handler: rhea.OnAmqpEvent): void {
-    this._receiver.removeListener(event, handler);
-  }
-
-  /**
-   * Registers the given handler for the specified event on the session object.
-   * @param {rhea.SessionEvents} event The event for which the handler needs to be registered.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be executed when the event
-   * occurs
-   * @returns {void} void.
-   */
-  registerSessionHandler(event: rhea.SessionEvents, handler: rhea.OnAmqpEvent): void {
-    this._session.registerHandler(event, handler);
-  }
-
-  /**
-   * Removes the given handler for the specified event from the session object.
-   * @param {rhea.SessionEvents} event The event for which the handler needs to be removed.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be removed.
-   * @returns {void} void.
-   */
-  removeSessionHandler(event: rhea.SessionEvents, handler: rhea.OnAmqpEvent): void {
-    this._session.removeHandler(event, handler);
+    (this._link as RheaReceiver).set_credit_window(creditWindow);
   }
 }

--- a/lib/sender.ts
+++ b/lib/sender.ts
@@ -1,119 +1,81 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
-import * as rhea from "rhea";
-import * as log from "./log";
+import {
+  SenderOptions as RheaSenderOptions, OnAmqpEvent, Delivery, Message, Sender as RheaSender
+} from "rhea";
 import { Session } from "./session";
-import { Connection } from "./connection";
 import { SenderEvents } from "rhea";
-import { Func } from "./util/utils";
+import { Link, LinkType } from './link';
 
 /**
  * Descibes the options that can be provided while creating an AMQP sender.
  * @interface SenderOptions
  */
-export interface SenderOptions extends rhea.SenderOptions {
+export interface SenderOptions extends RheaSenderOptions {
   /**
-   * @property {rhea.OnAmqpEvent} [onAccepted] The handler that can be provided for receiving the
+   * @property {OnAmqpEvent} [onAccepted] The handler that can be provided for receiving the
    * "accepted" event after a message is sent from the underlying rhea sender.
    */
-  onAccepted?: rhea.OnAmqpEvent;
+  onAccepted?: OnAmqpEvent;
   /**
-   * @property {rhea.OnAmqpEvent} [onRejected] The handler that can be provided for receiving the
+   * @property {OnAmqpEvent} [onRejected] The handler that can be provided for receiving the
    * "rejected" event after a message is sent from the underlying rhea sender.
    */
-  onRejected?: rhea.OnAmqpEvent;
+  onRejected?: OnAmqpEvent;
   /**
-   * @property {rhea.OnAmqpEvent} [onReleased] The handler that can be provided for receiving the
+   * @property {OnAmqpEvent} [onReleased] The handler that can be provided for receiving the
    * "released" event after a message is sent from the underlying rhea sender.
    */
-  onReleased?: rhea.OnAmqpEvent;
+  onReleased?: OnAmqpEvent;
   /**
-   * @property {rhea.OnAmqpEvent} [onModified] The handler that can be provided for receiving the
+   * @property {OnAmqpEvent} [onModified] The handler that can be provided for receiving the
    * "modified" event after a message is sent from the underlying rhea sender.
    */
-  onModified?: rhea.OnAmqpEvent;
+  onModified?: OnAmqpEvent;
   /**
-   * @property {rhea.OnAmqpEvent} [onError] The handler that can be provided for receiving any
+   * @property {OnAmqpEvent} [onError] The handler that can be provided for receiving any
    * errors that occur on the "sender_error" event.
    */
-  onError?: rhea.OnAmqpEvent;
+  onError?: OnAmqpEvent;
   /**
-   * @property {rhea.OnAmqpEvent} [onClose] The handler that can be provided for receiving the
+   * @property {OnAmqpEvent} [onClose] The handler that can be provided for receiving the
    * "sender_close" event.
    */
-  onClose?: rhea.OnAmqpEvent;
+  onClose?: OnAmqpEvent;
   /**
-   * @property {rhea.OnAmqpEvent} [onSessionError] The handler that can be provided for receiving
+   * @property {OnAmqpEvent} [onSessionError] The handler that can be provided for receiving
    * the "session_error" event that occurs on the underlying session.
    */
-  onSessionError?: rhea.OnAmqpEvent;
+  onSessionError?: OnAmqpEvent;
   /**
-   * @property {rhea.OnAmqpEvent} [onSessionClose] The handler that can be provided for receiving the
+   * @property {OnAmqpEvent} [onSessionClose] The handler that can be provided for receiving the
    * "session_close" event that occurs on the underlying session.
    */
-  onSessionClose?: rhea.OnAmqpEvent;
+  onSessionClose?: OnAmqpEvent;
+}
+
+/**
+ * Describes the event listeners that can be added to the Sender.
+ * @interface Sender
+ */
+export declare interface Sender {
+  on(event: SenderEvents, listener: OnAmqpEvent): this;
 }
 
 /**
  * Describes the sender that wraps the rhea sender.
  * @class Sender
  */
-export class Sender {
+export class Sender extends Link {
   senderOptions?: SenderOptions;
-  private _session: Session;
-  private _sender: rhea.Sender;
 
-  constructor(session: Session, sender: rhea.Sender, options?: SenderOptions) {
-    this._session = session;
-    this._sender = sender;
-    this.senderOptions = options;
+  constructor(session: Session, sender: RheaSender, options?: SenderOptions) {
+    super(LinkType.sender, session, sender, options);
   }
 
-  get name(): string {
-    return this._sender.name;
-  }
-
-  get error(): rhea.AmqpError | Error | undefined {
-    return this._sender.error;
-  }
-
-  get properties(): rhea.Dictionary<any> {
-    return this._sender.properties;
-  }
-
-  get source(): rhea.Source {
-    return this._sender.source;
-  }
-
-  get target(): rhea.TerminusOptions {
-    return this._sender.target;
-  }
-
-  get address(): string {
-    return this.source.address;
-  }
-  get credit(): number {
-    return (this._sender as any).credit;
-  }
-
-  get session(): Session {
-    return this._session;
-  }
-
-  get connection(): Connection {
-    return this._session.connection;
+  setDrained(drained: boolean): void {
+    (this._link as RheaSender).set_drained(drained);
   }
 
   /**
@@ -121,202 +83,17 @@ export class Sender {
    * @returns {boolean} `true` Sendable. `false` Not Sendable.
    */
   sendable(): boolean {
-    return this._sender.sendable();
+    return (this._link as RheaSender).sendable();
   }
 
   /**
    * Sends the message
-   * @param {rhea.Message | Buffer} msg The AMQP message to be sent.
+   * @param {Message | Buffer} msg The AMQP message to be sent.
    * @param {Buffer | string} [tag] The optional tag that can be sent
    * @param {number} [format] The format in which the message needs to be sent.
-   * @returns {rhea.Delivery} Delivery The delivery information about the sent message.
+   * @returns {Delivery} Delivery The delivery information about the sent message.
    */
-  send(msg: rhea.Message | Buffer, tag?: Buffer | string, format?: number): rhea.Delivery {
-    return this._sender.send(msg, tag, format);
-  }
-
-  /**
-   * Determines whether the sender link and its underlying session is open.
-   * @returns {boolean} `true` open. `false` closed.
-   */
-  isOpen(): boolean {
-    let result = false;
-    if (this._session.isOpen() && this._sender.is_open()) {
-      result = true;
-    }
-    return result;
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for link or it's underlying session
-   * or it's underlying connection are closed.
-   * Within the "sender_close", "session_close" event handler, if this
-   * method returns `false` it means that the local end is still open. It can be useful to
-   * determine whether the close was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` if closed, `false` otherwise.
-   */
-  isClosed(): boolean {
-    return this._sender.is_closed();
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for just the link itself are closed.
-   * Within the "sender_close" event handler, if this method returns `false` it
-   * means that the local end is still open. It can be useful to determine whether the close
-   * was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` - closed, `false` otherwise.
-   */
-  isItselfClosed(): boolean {
-    return this._sender.is_itself_closed();
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for session or it's underlying
-   * connection are closed.
-   *
-   * Within the "session_close" event handler, if this method returns `false` it means that
-   * the local end is still open. It can be useful to determine whether the close
-   * was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` - closed, `false` otherwise.
-   */
-  isSessionClosed(): boolean {
-    return this._session.isClosed();
-  }
-
-  /**
-   * Determines whether both local and remote endpoint for just the session itself are closed.
-   * Within the "session_close" event handler, if this method returns `false` it means that
-   * the local end is still open. It can be useful to determine whether the close
-   * was initiated locally under such circumstances.
-   *
-   * @returns {boolean} `true` - closed, `false` otherwise.
-   */
-  isSessionItselfClosed(): boolean {
-    return this._session.isItselfClosed();
-  }
-
-  /**
-   * Removes the sender and it's underlying session from the internal map.
-   * @returns {void} void
-   */
-  remove(): void {
-    if (this._sender) {
-      this._sender.remove();
-    }
-    if (this._session) {
-      this._session.remove();
-    }
-  }
-
-  /**
-   * Closes the amqp sender.
-   * @return {Promise<void>} Promise<void>
-   * - **Resolves** the promise when rhea emits the "sender_close" event.
-   * - **Rejects** the promise with an AmqpError when rhea emits the
-   * "sender_error" event while trying to close an amqp sender.
-   */
-  close(): Promise<void> {
-    const senderClose = new Promise<void>((resolve, reject) => {
-      log.error("[%s] The sender is open ? -> %s", this.connection.id, this.isOpen());
-      if (this.isOpen()) {
-        let onError: Func<rhea.EventContext, void>;
-        let onClose: Func<rhea.EventContext, void>;
-        let waitTimer: any;
-
-        const removeListeners = () => {
-          clearTimeout(waitTimer);
-          this._sender.removeListener(SenderEvents.senderError, onError);
-          this._sender.removeListener(SenderEvents.senderClose, onClose);
-        };
-
-        onClose = (context: rhea.EventContext) => {
-          removeListeners();
-          setTimeout(() => {
-            log.sender("[%s] Resolving the promise as the amqp sender has been closed.",
-              this.connection.id);
-            resolve();
-          });
-        };
-
-        onError = (context: rhea.EventContext) => {
-          removeListeners();
-          log.error("[%s] Error occurred while closing amqp sender: %O.",
-            this.connection.id, context.session!.error);
-          reject(context.session!.error);
-        };
-
-        const actionAfterTimeout = () => {
-          removeListeners();
-          const msg: string = `Unable to close the amqp sender ${this.name} due to operation timeout.`;
-          log.error("[%s] %s", this.connection.id, msg);
-          reject(new Error(msg));
-        };
-
-        this._sender.once(SenderEvents.senderClose, onClose);
-        this._sender.once(SenderEvents.senderError, onError);
-        waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
-        this._sender.close();
-      } else {
-        resolve();
-      }
-    });
-
-    return senderClose.then(() => {
-      log.sender("[%s] sender has been closed, now closing it's session.", this.connection.id);
-      return this._session.close();
-    });
-  }
-
-  setMaxListeners(count: number): void {
-    this._sender.setMaxListeners(count);
-  }
-
-  getMaxListeners(): number {
-    return this._sender.getMaxListeners();
-  }
-
-  /**
-   * Registers the given handler for the specified event.
-   * @param {rhea.SenderEvents} event The event for which the handler needs to be registered.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be executed when the event
-   * occurs
-   * @returns {void} void.
-   */
-  registerHandler(event: SenderEvents, handler: rhea.OnAmqpEvent): void {
-    this._sender.on(event, handler);
-  }
-
-  /**
-   * Removes the given handler for the specified event.
-   * @param {rhea.SenderEvents} event The event for which the handler needs to be removed.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be removed.
-   * @returns {void} void.
-   */
-  removeHandler(event: SenderEvents, handler: rhea.OnAmqpEvent): void {
-    this._sender.removeListener(event, handler);
-  }
-
-  /**
-   * Registers the given handler for the specified event on the session object.
-   * @param {rhea.SessionEvents} event The event for which the handler needs to be registered.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be executed when the event
-   * occurs
-   * @returns {void} void.
-   */
-  registerSessionHandler(event: rhea.SessionEvents, handler: rhea.OnAmqpEvent): void {
-    this._session.registerHandler(event, handler);
-  }
-
-  /**
-   * Removes the given handler for the specified event from the session object.
-   * @param {rhea.SessionEvents} event The event for which the handler needs to be removed.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be removed.
-   * @returns {void} void.
-   */
-  removeSessionHandler(event: rhea.SessionEvents, handler: rhea.OnAmqpEvent): void {
-    this._session.removeHandler(event, handler);
+  send(msg: Message | Buffer, tag?: Buffer | string, format?: number): Delivery {
+    return (this._link as RheaSender).send(msg, tag, format);
   }
 }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,16 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
 import * as rhea from "rhea";
 import * as log from "./log";
@@ -19,18 +8,29 @@ import { Receiver, ReceiverOptions } from "./receiver";
 import { Sender, SenderOptions } from "./sender";
 import { SenderEvents, ReceiverEvents, SessionEvents } from "rhea";
 import { Func } from "./util/utils";
+import { EventEmitter } from "events";
+
+/**
+ * Describes the event listeners that can be added to the Session.
+ * @interface Session
+ */
+export declare interface Session {
+  on(event: SessionEvents, listener: rhea.OnAmqpEvent): this;
+}
 
 /**
  * Describes the session that wraps the rhea session.
  * @class Session
  */
-export class Session {
+export class Session extends EventEmitter {
   private _session: rhea.Session;
   private _connection: Connection;
 
   constructor(connection: Connection, session: rhea.Session) {
+    super();
     this._connection = connection;
     this._session = session;
+    this._initializeEventListeners();
   }
   /**
    * @property {Connection} connection The underlying AMQP connection.
@@ -105,8 +105,8 @@ export class Session {
 
         const removeListeners = () => {
           clearTimeout(waitTimer);
-          this._session.removeListener(SessionEvents.sessionError, onError);
-          this._session.removeListener(SessionEvents.sessionClose, onClose);
+          this.removeListener(SessionEvents.sessionError, onError);
+          this.removeListener(SessionEvents.sessionClose, onClose);
         };
 
         onClose = (context: rhea.EventContext) => {
@@ -132,8 +132,8 @@ export class Session {
           reject(new Error(msg));
         };
 
-        this._session.once(SessionEvents.sessionClose, onClose);
-        this._session.once(SessionEvents.sessionError, onError);
+        this.once(SessionEvents.sessionClose, onClose);
+        this.once(SessionEvents.sessionError, onError);
         log.session("[%s] Calling session.close()", this.connection.id);
         waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
         this._session.close();
@@ -163,11 +163,11 @@ export class Session {
       const handlersProvided = options && options.onMessage ? true : false;
       // Register session handlers for session_error and session_close if provided.
       if (options && options.onSessionError) {
-        this._session.on(SessionEvents.sessionError, options.onSessionError);
+        this.on(SessionEvents.sessionError, options.onSessionError);
       }
 
       if (options && options.onSessionClose) {
-        this._session.on(SessionEvents.sessionClose, options.onSessionClose);
+        this.on(SessionEvents.sessionClose, options.onSessionClose);
       }
       const rheaReceiver = this._session.attach_receiver(options);
       const receiver = new Receiver(this, rheaReceiver, options);
@@ -176,25 +176,25 @@ export class Session {
       let waitTimer: any;
 
       if (handlersProvided) {
-        rheaReceiver.on(ReceiverEvents.message, options!.onMessage!);
-        rheaReceiver.on(ReceiverEvents.receiverError, options!.onError!);
+        receiver.on(ReceiverEvents.message, options!.onMessage!);
+        receiver.on(ReceiverEvents.receiverError, options!.onError!);
       }
 
       if (options && options.onClose) {
-        rheaReceiver.on(ReceiverEvents.receiverClose, options.onClose);
+        receiver.on(ReceiverEvents.receiverClose, options.onClose);
       }
 
       const removeListeners = () => {
         clearTimeout(waitTimer);
-        rheaReceiver.removeListener(ReceiverEvents.receiverOpen, onOpen);
-        rheaReceiver.removeListener(ReceiverEvents.receiverClose, onClose);
+        receiver.removeListener(ReceiverEvents.receiverOpen, onOpen);
+        receiver.removeListener(ReceiverEvents.receiverClose, onClose);
       };
 
       onOpen = (context: rhea.EventContext) => {
         removeListeners();
         setTimeout(() => {
           log.session("[%s] Resolving the promise with amqp receiver '%s'.",
-            this.connection.id, rheaReceiver.name);
+            this.connection.id, receiver.name);
           resolve(receiver);
         });
       };
@@ -208,14 +208,14 @@ export class Session {
 
       const actionAfterTimeout = () => {
         removeListeners();
-        const msg: string = `Unable to create the amqp receiver ${rheaReceiver.name} due to ` +
+        const msg: string = `Unable to create the amqp receiver ${receiver.name} due to ` +
           `operation timeout.`;
         log.error("[%s] %s", this.connection.id, msg);
         reject(new Error(msg));
       };
 
-      rheaReceiver.once(ReceiverEvents.receiverOpen, onOpen);
-      rheaReceiver.once(ReceiverEvents.receiverClose, onClose);
+      receiver.once(ReceiverEvents.receiverOpen, onOpen);
+      receiver.once(ReceiverEvents.receiverClose, onClose);
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
     });
   }
@@ -232,11 +232,11 @@ export class Session {
     return new Promise((resolve, reject) => {
       // Register session handlers for session_error and session_close if provided.
       if (options && options.onSessionError) {
-        this._session.on(SessionEvents.sessionError, options.onSessionError);
+        this.on(SessionEvents.sessionError, options.onSessionError);
       }
 
       if (options && options.onSessionClose) {
-        this._session.on(SessionEvents.sessionClose, options.onSessionClose);
+        this.on(SessionEvents.sessionClose, options.onSessionClose);
       }
 
       const rheaSender = this._session.attach_sender(options);
@@ -247,36 +247,36 @@ export class Session {
 
       if (options) {
         if (options.onError) {
-          rheaSender.on(SenderEvents.senderError, options.onError);
+          sender.on(SenderEvents.senderError, options.onError);
         }
         if (options.onClose) {
-          rheaSender.on(SenderEvents.senderClose, options.onClose);
+          sender.on(SenderEvents.senderClose, options.onClose);
         }
         if (options.onAccepted) {
-          rheaSender.on(SenderEvents.accepted, options.onAccepted);
+          sender.on(SenderEvents.accepted, options.onAccepted);
         }
         if (options.onRejected) {
-          rheaSender.on(SenderEvents.rejected, options.onRejected);
+          sender.on(SenderEvents.rejected, options.onRejected);
         }
         if (options.onReleased) {
-          rheaSender.on(SenderEvents.released, options.onReleased);
+          sender.on(SenderEvents.released, options.onReleased);
         }
         if (options.onModified) {
-          rheaSender.on(SenderEvents.modified, options.onModified);
+          sender.on(SenderEvents.modified, options.onModified);
         }
       }
 
       const removeListeners = () => {
         clearTimeout(waitTimer);
-        rheaSender.removeListener(SenderEvents.senderOpen, onSendable);
-        rheaSender.removeListener(SenderEvents.senderClose, onClose);
+        sender.removeListener(SenderEvents.senderOpen, onSendable);
+        sender.removeListener(SenderEvents.senderClose, onClose);
       };
 
       onSendable = (context: rhea.EventContext) => {
         removeListeners();
         setTimeout(() => {
           log.session("[%s] Resolving the promise with amqp sender '%s'.",
-            this.connection.id, rheaSender.name);
+            this.connection.id, sender.name);
           resolve(sender);
         });
       };
@@ -290,57 +290,42 @@ export class Session {
 
       const actionAfterTimeout = () => {
         removeListeners();
-        const msg: string = `Unable to create the amqp sender ${rheaSender.name} due to ` +
+        const msg: string = `Unable to create the amqp sender ${sender.name} due to ` +
           `operation timeout.`;
         log.error("[%s] %s", this.connection.id, msg);
         reject(new Error(msg));
       };
 
-      rheaSender.once(SenderEvents.sendable, onSendable);
-      rheaSender.once(SenderEvents.senderClose, onClose);
+      sender.once(SenderEvents.sendable, onSendable);
+      sender.once(SenderEvents.senderClose, onClose);
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
     });
   }
 
   /**
-   * Registers the given handler for the specified event.
-   * @param {rhea.SessionEvents} event The event for which the handler needs to be registered.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be executed when the event
-   * occurs
-   * @returns {void} void.
+   * Adds event listeners for the possible events that can occur on the session object and
+   * re-emits the same event back with the received arguments from rhea's event emitter.
+   * @private
+   * @returns {void} void
    */
-  registerHandler(event: rhea.SessionEvents, handler: rhea.OnAmqpEvent): void {
-    this._session.on(event, handler);
-  }
+  private _initializeEventListeners(): void {
 
-  /**
-   * Removes the given handler for the specified event.
-   * @param {rhea.SessionEvents} event The event for which the handler needs to be removed.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be removed.
-   * @returns {void} void.
-   */
-  removeHandler(event: rhea.SessionEvents, handler: rhea.OnAmqpEvent): void {
-    this._session.removeListener(event, handler);
-  }
+    for (const eventName in SessionEvents) {
+      this._session.on(SessionEvents[eventName],
+        (...args) => this.emit(SessionEvents[eventName], ...args));
+    }
 
-  /**
-   * Registers the given handler for the specified event on the connection object.
-   * @param {rhea.ConnectionEvents} event The event for which the handler needs to be registered.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be executed when the event
-   * occurs
-   * @returns {void} void.
-   */
-  registerConnectionHandler(event: rhea.ConnectionEvents, handler: rhea.OnAmqpEvent): void {
-    this._connection.registerHandler(event, handler);
-  }
-
-  /**
-   * Removes the given handler for the specified event from the connection object.
-   * @param {rhea.ConnectionEvents} event The event for which the handler needs to be removed.
-   * @param {rhea.OnAmqpEvent} handler The handler function that needs to be removed.
-   * @returns {void} void.
-   */
-  removeConnectionHandler(event: rhea.ConnectionEvents, handler: rhea.OnAmqpEvent): void {
-    this._connection.removeHandler(event, handler);
+    // Add event handlers for *_error and *_close events that can be propogated to the session
+    // object, if they are not handled at their level. * denotes - Sender and Receiver.
+    // Sender
+    this._session.on(rhea.SenderEvents.senderError,
+      (...args) => this.emit(rhea.SenderEvents.senderError, ...args));
+    this._session.on(rhea.SenderEvents.senderClose,
+      (...args) => this.emit(rhea.SenderEvents.senderClose, ...args));
+    // Receiver
+    this._session.on(rhea.ReceiverEvents.receiverError,
+      (...args) => this.emit(rhea.ReceiverEvents.receiverError, ...args));
+    this._session.on(rhea.ReceiverEvents.receiverClose,
+      (...args) => this.emit(rhea.ReceiverEvents.receiverClose, ...args));
   }
 }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -78,6 +78,9 @@ export class Session extends EventEmitter {
 
   remove(): void {
     if (this._session) {
+      // Remove our listeners and listeners from rhea's session object.
+      this.removeAllListeners();
+      this._session.removeAllListeners();
       this._session.remove();
     }
   }

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -1,16 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
 /**
  * Describes the default operation timeout in seconds. Value: `60`.

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -1,17 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache License. See License in the project root for license information.
 
 /**
  * Defines a mapping for Http like response status codes for different status-code values

--- a/package-lock.json
+++ b/package-lock.json
@@ -338,11 +338,11 @@
       }
     },
     "rhea": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-0.3.1.tgz",
-      "integrity": "sha512-2M01e5eFGfo62mPOr4eANUfhvajm557pCoXJiWYDFgelCcFu0WwBcLatdkLvhaiLilUuZ889aPVSzoqoBZJXdw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-0.3.2.tgz",
+      "integrity": "sha512-M/iuw38dVDcz8hmeZmzcgWcQ/40JLgaJW/hcNjHUXmUb02zUfsA9T0KE9qxQVW+Jxe5kHq/osLkbJ+fCcu4wzA==",
       "requires": {
-        "debug": ">=0.8.0"
+        "debug": "0.8.0 - 3.5.0"
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -443,9 +443,9 @@
       }
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
       "dev": true
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,15 +25,6 @@
       "integrity": "sha512-iHsAzDg3OLH7JP+wipniUULHoDSWLgEDYOvsar6/mpAkTJd9/n23Ap8ikruMlvRTqMv/LXrflH9v/AfiEqaBGg==",
       "dev": true
     },
-    "@types/uuid": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
-      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
     "debug": "^3.1.0",
-    "rhea": "^0.3.1"
+    "rhea": "^0.3.2"
   },
   "keywords": [
     "amqp",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/dotenv": "^4.0.3",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
-    "typescript": "^3.0.1",
+    "typescript": "^3.0.3",
     "dotenv": "^6.0.0"
   },
   "scripts": {

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,12 @@
+AMQP_HOST="name of the host,ex: foo.servicebus.windows.net"
+AMQP_USERNAME="username, ex: RootManagedSharedAccessKey"
+AMQP_PASSWORD="sharedAccessKeyValue"
+AMQP_PORT=5672
+# - For Azure EventHub
+#   - EventHub Receiver: "<hubName>/ConsumerGroups/<ConsumerGroupName>/Partitions/<PartitionId>"
+RECEIVER_ADDRESS="address of the receiver"
+# - For Azure EventHub
+#   - PartitionedSender: "<hubName>/Partitions/<PartitionId>"
+#   - Normal Sender: "<hubName>"
+SENDER_ADDRESS="address of the sender"
+DEBUG=rhea*,-rhea:raw,-rhea:message,-azure:amqp-common:datatransformer


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- Uses the EventEmitter pattern based on the feedback provided in the previous PR.
- Updated receive example to use the EventEmitter pattern
- Ensured that the send/receive examples work against Azure EventHub
- Updated the README.md with examples for send/receive, how to provide debug logs and how to save debug logs to a file
- Provided a `sample.env` which shows how to provide sample values for host, address, etc.
