### PR TITLE
Add missing dependency to package.json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### 0.1.9 - 2018-10-24
+- With the usage of `importHelpers`, the tslib will be needed in package.json for installers using older versions of npm (or using yarn). [PR](https://github.com/amqp/rhea-promise/pull/16).
+
 ### 0.1.8 - 2018-10-22
 - Allow setting drain property on the receiver [PR](https://github.com/amqp/rhea-promise/pull/14).
 
@@ -5,12 +8,12 @@
 - Fixed a bug while populating the connectionId [PR](https://github.com/amqp/rhea-promise/pull/11).
 
 ### 0.1.6 - 2018-09-28
-- property `actionInitiated` is now of type `number` which is incremented when the `create`, `close` 
+- property `actionInitiated` is now of type `number` which is incremented when the `create`, `close`
 action on an entity is under process and decremented when the action completes (succeeeded or failed).
 
 ### 0.1.5 - 2018-09-27
 - Improved log statements for better debugging.
-- Any type of `error` event will be emitted with a tick delay. This would give enough time for the 
+- Any type of `error` event will be emitted with a tick delay. This would give enough time for the
 `create()` methods to resolve the promise.
 - Added a new `boolean` property `actionInitiated` which indicates whether the `create`, `close`
 action on an entity is under process.
@@ -20,7 +23,7 @@ action on an entity is under process.
 
 ### 0.1.3 - 2018-09-25
 - Transform relevant objects in rhea EventContext to rhea-promise objects.
-- Ensure that `container.createConnection()` creates a connection on that container and not on 
+- Ensure that `container.createConnection()` creates a connection on that container and not on
 the default container.
 
 ### 0.1.2 - 2018-09-20

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,8 +421,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
     "debug": "^3.1.0",
-    "rhea": "^0.3.3"
+    "rhea": "^0.3.3",
+    "tslib": "^1.9.3"
   },
   "keywords": [
     "amqp",


### PR DESCRIPTION
With the usage of `importHelpers`, the `tslib` will be needed in `package.json` for installers using older versions of npm (or using yarn).