### PR TITLE
Commit typings and dist folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prebuild": "rimraf dist && rimraf typings",
     "build": "npm run tslint && npm run tsc",
     "test": "npm run build",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "prepack": "npm i && npm run build"
   },
   "homepage": "https://github.com/amqp/rhea-promise",
   "repository": {


### PR DESCRIPTION
Similarly to `rhea`, commit the dist and typings folders. Package managers don't run build commands when pulling from git directly.