### PR TITLE
Providing an option to add onSettled event handler

### DIFF
--- a/lib/receiver.ts
+++ b/lib/receiver.ts
@@ -14,6 +14,11 @@ import { OnAmqpEvent } from "./eventContext";
  */
 export interface ReceiverOptions extends RheaReceiverOptions {
   /**
+   * @property {OnAmqpEvent} [onSettled] The handler that can be provided for receiving the
+   * "settled" event when a message is received on the underling rhea receiver.
+   */
+  onSettled?: OnAmqpEvent;
+  /**
    * @property {OnAmqpEvent} [onMessage] The handler that can be provided for receiving the
    * "message" event when a message is received on the underling rhea receiver.
    */

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -206,6 +206,12 @@ export class Session extends Entity {
           this.connection.id, ReceiverEvents.receiverClose);
       }
 
+      if (options && options.onSettled) {
+        receiver.on(ReceiverEvents.settled, options.onSettled);
+        log.receiver("[%s] Added event handler for event '%s' on rhea-promise 'receiver'.",
+          this.connection.id, ReceiverEvents.settled);
+      }
+
       const removeListeners = () => {
         clearTimeout(waitTimer);
         receiver.actionInitiated--;


### PR DESCRIPTION
- Based on the fixes made in amqp/rhea#155
- Users can provide an event handler on the Receiver for the "settled" event. This is useful for receiving dispositions in response to the dispositions sent (accept, reject, modified, release) to the service.
- In the event handler for `"settled"` event
  - The disposition can be correlated by `context.delivery.id` 
  - One should look for `context.delivery.remote_settled`
  - If an error was received then it will possibly be present at `context.delivery.remote_state.error` (For some reason, while doing a console.log(context.delivery.remote_state), it does not log the error property but it is present when an erroneous response is received.