### PR TITLE
Fix for error on @azure/event-hubs library - https://github.com/Azure…

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -575,7 +575,9 @@ export class Connection extends Entity {
       emitEvent(params);
     });
 
-    log.eventHandler("[%s] rhea-promise 'connection' object is listening for events: %o " +
-      "emitted by rhea's 'connection' object.", this.id, this._connection.eventNames());
+    if (typeof this._connection.eventNames === "function") {
+      log.eventHandler("[%s] rhea-promise 'connection' object is listening for events: %o " +
+        "emitted by rhea's 'connection' object.", this.id, this._connection.eventNames());
+    }
   }
 }


### PR DESCRIPTION
…/azure-event-hubs-node

TypeError: this._connection.eventNames is not a function
    at Connection._initializeEventListeners (connection.js:613)
    at new Connection (connection.js:81)
    at Object.create (ConnectionContextBase.js:59)
    at Object.create (connectionContext.js:55)
    at new EventHubClient (eventHubClient.js:63)
    at Function.createFromConnectionString (eventHubClient.js:486)
    at Object.log (eventHubApi.js:7)
    at _callee$ (actions.js:35)
    at tryCatch (runtime.js:62)
    at Generator.invoke [as _invoke] (runtime.js:288)
    at Generator.prototype.(:3000/anonymous function) [as next] (http://localhost:3000/static/js/24.chunk.js:9099:21)
    at asyncGeneratorStep (asyncToGenerator.js:3)
    at _next (asyncToGenerator.js:25)

## Description

Brief description of the changes made in the PR. This helps in making better changelog
Fixed issue of missing method call.

# Reference to any github issues
https://github.com/amqp/rhea-promise/issues/20
