### PR TITLE
Update major version for rhea in dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -286,13 +286,13 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -301,7 +301,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -343,9 +343,9 @@
       }
     },
     "rhea": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-0.3.5.tgz",
-      "integrity": "sha512-0FBxkW1fThGRZaUSYXWZ98M6QGLQHZRjP7BnY+d7g/1RxG3Kj+rL220xjlRe0EC+8cklKM5KLdesdesEnuPWPw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.0.tgz",
+      "integrity": "sha512-bJz7p4rEcIAmIsTGI54J0oGQ04FiZ8M/FhtMwpXyxWEoeOpYu6Wi4YR6o0f8K53QFE4LbPCHbfE5bAlCeDPE2w==",
       "requires": {
         "debug": "0.8.0 - 3.5.0"
       }
@@ -389,7 +389,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
     "debug": "^3.1.0",
-    "rhea": "^0.3.5",
+    "rhea": "^1.0.0",
     "tslib": "^1.9.3"
   },
   "keywords": [


### PR DESCRIPTION
Now that we have a major version release for rhea, we should update our dependencies to use it as well

cc @grs, @amarzavery 