### PR TITLE
 removeAllSessions() to clean up connection.

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -380,7 +380,9 @@ export class Connection extends Entity {
    * Remove all the sessions from the internal map.
    */
   removeAllSessions(): void {
-    return this._connection.remove_all_sessions();
+    if (this._connection) {
+      this._connection.remove_all_sessions();
+    }
   }
 
   /**

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -377,6 +377,13 @@ export class Connection extends Entity {
   }
 
   /**
+   * Remove all the sessions from the internal map.
+   */
+  removeAllSessions(): void {
+    return this._connection.remove_all_sessions();
+  }
+
+  /**
    * Determines whether the remote end of the connection is open.
    * @returns {boolean} result `true` - is open; `false` otherwise.
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,9 +343,9 @@
       }
     },
     "rhea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.0.tgz",
-      "integrity": "sha512-bJz7p4rEcIAmIsTGI54J0oGQ04FiZ8M/FhtMwpXyxWEoeOpYu6Wi4YR6o0f8K53QFE4LbPCHbfE5bAlCeDPE2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.2.tgz",
+      "integrity": "sha512-ZbF1fe90TIu+nhzu5vvf9Xg4OhWO2p2FSGv97SBwPn2CpDy0CRjOxGQYu2eeqSukmZc9D+aQX6lOMQUF0pO16g==",
       "requires": {
         "debug": "0.8.0 - 3.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
     "debug": "^3.1.0",
-    "rhea": "^1.0.0",
+    "rhea": "^1.0.2",
     "tslib": "^1.9.3"
   },
   "keywords": [


### PR DESCRIPTION
This PR adds a new function `removeAllSessions()` that calls `remove_all_sessions()` method of rhea that calls on the connection to clear the internal map for sessions.

**Reference** : https://github.com/amqp/rhea/pull/207

cc @AlexGhiondea @ramya-rao-a 

