### PR TITLE
Expose rhea types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,7 +7,7 @@ export {
   uuid_to_string, generate_uuid, string_to_uuid, LinkError, ProtocolError, LinkOptions,
   DeliveryAnnotations, MessageAnnotations, ReceiverEvents, SenderEvents, ConnectionEvents,
   SessionEvents, ContainerOptions as ContainerOptionsBase, TerminusOptions, Types, Sasl,
-  EndpointOptions, MessageUtil, TypeError, SimpleError, Source, ConnectionError
+  EndpointOptions, MessageUtil, TypeError, SimpleError, Source, ConnectionError, Typed
 } from "rhea";
 
 export { EventContext, OnAmqpEvent } from "./eventContext";
@@ -22,4 +22,3 @@ export {
   Func, AmqpResponseStatusCode, isAmqpError, ConnectionStringParseOptions, delay, messageHeader,
   messageProperties, parseConnectionString, ParsedOutput
 } from "./util/utils";
-export { Typed } from "rhea/typings/types";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,3 +22,4 @@ export {
   Func, AmqpResponseStatusCode, isAmqpError, ConnectionStringParseOptions, delay, messageHeader,
   messageProperties, parseConnectionString, ParsedOutput
 } from "./util/utils";
+export { Typed } from "rhea/typings/types";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -343,9 +343,9 @@
       }
     },
     "rhea": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.2.tgz",
-      "integrity": "sha512-ZbF1fe90TIu+nhzu5vvf9Xg4OhWO2p2FSGv97SBwPn2CpDy0CRjOxGQYu2eeqSukmZc9D+aQX6lOMQUF0pO16g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.3.tgz",
+      "integrity": "sha512-pSLMLtcr9FcYlHcMng4QrpJZ3mPB35uc8WnAyQflYTJHeBz02A67T1N30xYnANyQGtp0NtlIRh0BI8h7h05CoA==",
       "requires": {
         "debug": "0.8.0 - 3.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
     "debug": "^3.1.0",
-    "rhea": "^1.0.2",
+    "rhea": "^1.0.3",
     "tslib": "^1.9.3"
   },
   "keywords": [


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR.
- These changes delink library users from depending on Rhea for inferring the underlying types


# Reference to any github issues
- https://github.com/Azure/azure-sdk-for-js/issues/2070
