### PR TITLE
Timeout for the AwaitableSender's send

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### 1.0.1 - #Unreleased
+- Added a `timeoutInSeconds` parameter to the `send` method on the `AwaitableSender`.
+
 ### 1.0.0 - 2019-06-27
 - Updated minimum version of `rhea` to `^1.0.8`.
 - Added a read only property `id` to the `Session` object. The id property is created by concatenating session's local channel, remote channel and the connection id `"local-<number>_remote-<number>_<connection-id>"`, thus making it unique for that connection.

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -170,9 +170,9 @@ export class AwaitableSender extends BaseSender {
    * @param {number} [format] The message format. Specify this if a message with custom format needs
    * to be sent. `0` implies the standard AMQP 1.0 defined format. If no value is provided, then the
    * given message is assumed to be of type Message interface and encoded appropriately.
-   * @param {number} [timeoutInSeconds] If provided, this timeout overrides the `sendTimeoutInSeconds` 
-   * that is set when the `AwaitableSender` is created. This timeout represents the duration in which 
-   * the promise to send the message should complete (resolve/reject). If not, the Promise will be 
+   * @param {number} [timeoutInSeconds] If provided, this timeout overrides the `sendTimeoutInSeconds`
+   * that is set when the `AwaitableSender` is created. This timeout represents the duration in which
+   * the promise to send the message should complete (resolve/reject). If not, the Promise will be
    * rejected after timeout.
    * @returns {Promise<Delivery>} Promise<Delivery> The delivery information about the sent message.
    */

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -170,14 +170,19 @@ export class AwaitableSender extends BaseSender {
    * @param {number} [format] The message format. Specify this if a message with custom format needs
    * to be sent. `0` implies the standard AMQP 1.0 defined format. If no value is provided, then the
    * given message is assumed to be of type Message interface and encoded appropriately.
+   * @param {number} [timeoutInSeconds] If provided, this timeout overrides the `sendTimeoutInSeconds` 
+   * that is set when the `AwaitableSender` is created. This timeout represents the duration in which 
+   * the promise to send the message should complete (resolve/reject). If not, the Promise will be 
+   * rejected after timeout.
    * @returns {Promise<Delivery>} Promise<Delivery> The delivery information about the sent message.
    */
-  send(msg: Message | Buffer, tag?: Buffer | string, format?: number): Promise<Delivery> {
+  send(msg: Message | Buffer, tag?: Buffer | string, format?: number, timeoutInSeconds?: number): Promise<Delivery> {
     return new Promise<Delivery>((resolve, reject) => {
       log.sender("[%s] Sender '%s' on amqp session '%s', credit: %d available: %d",
         this.connection.id, this.name, this.session.id, this.credit,
         this.session.outgoing.available());
       if (this.sendable()) {
+        if (timeoutInSeconds && typeof timeoutInSeconds == "number" && timeoutInSeconds > 0) this.sendTimeoutInSeconds = timeoutInSeconds;
         const timer = setTimeout(() => {
           this.deliveryDispositionMap.delete(delivery.id);
           const message = `Sender '${this.name}' on amqp session ` +

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -182,7 +182,7 @@ export class AwaitableSender extends BaseSender {
         this.connection.id, this.name, this.session.id, this.credit,
         this.session.outgoing.available());
       if (this.sendable()) {
-        let sendTimoutInSeconds = this.sendTimeoutInSeconds;
+        let sendTimeoutInSeconds = this.sendTimeoutInSeconds;
         if (typeof timeoutInSeconds === "number" && timeoutInSeconds > 0) sendTimeoutInSeconds = timeoutInSeconds;
         const timer = setTimeout(() => {
           this.deliveryDispositionMap.delete(delivery.id);
@@ -191,7 +191,7 @@ export class AwaitableSender extends BaseSender {
             `message with delivery id ${delivery.id} right now, due to operation timeout.`;
           log.error("[%s] %s", this.connection.id, message);
           return reject(new OperationTimeoutError(message));
-        }, this.sendTimeoutInSeconds * 1000);
+        }, sendTimeoutInSeconds * 1000);
 
         const delivery = (this._link as RheaSender).send(msg, tag, format);
         this.deliveryDispositionMap.set(delivery.id, {

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -182,7 +182,8 @@ export class AwaitableSender extends BaseSender {
         this.connection.id, this.name, this.session.id, this.credit,
         this.session.outgoing.available());
       if (this.sendable()) {
-        if (timeoutInSeconds && typeof timeoutInSeconds == "number" && timeoutInSeconds > 0) this.sendTimeoutInSeconds = timeoutInSeconds;
+        let sendTimoutInSeconds = this.sendTimeoutInSeconds;
+        if (typeof timeoutInSeconds === "number" && timeoutInSeconds > 0) sendTimeoutInSeconds = timeoutInSeconds;
         const timer = setTimeout(() => {
           this.deliveryDispositionMap.delete(delivery.id);
           const message = `Sender '${this.name}' on amqp session ` +


### PR DESCRIPTION
## Description
- Currently, there is no way to set the timeout for the send method other than relying on `sendTimeoutInSeconds` option when the `AwaitableSender` is created. 
- This PR attempts to add the `timeoutInSeconds` param to the `send` method which would override the `sendTimeoutInSeconds` if provided. This would remove the requirement to know the timeout to be set when the `AwaitableSender` is created. This would add the convenience of setting the timeout at the send call directly.

/cc - @ramya-rao-a @chradek @richardpark-msft