### PR TITLE
Use error on sender/receiver when reporting error on link closing

### DIFF
--- a/lib/link.ts
+++ b/lib/link.ts
@@ -265,9 +265,16 @@ export abstract class Link extends Entity {
 
         onError = (context: RheaEventContext) => {
           removeListeners();
+          let error = context.session!.error;
+          if (this.type === LinkType.sender && context.sender && context.sender.error) {
+            error = context.sender.error;
+          } else if (this.type === LinkType.receiver && context.receiver && context.receiver.error) {
+            error = context.receiver.error;
+          }
+
           log.error("[%s] Error occurred while closing %s '%s' on amqp session '%s': %O.",
-            this.connection.id, this.type, this.name, this.session.id, context.session!.error);
-          return reject(context.session!.error);
+            this.connection.id, this.type, this.name, this.session.id, error);
+          return reject(error);
         };
 
         onDisconnected = (context: RheaEventContext) => {


### PR DESCRIPTION
## Description

If the `error` event is fired on closing a link, we currently only report `context.session.error` as the error.
But, it can so happen that the error is actual on the sender/receiver based on the link type and there is no session error. We found this in https://github.com/Azure/azure-sdk-for-js/issues/9615

This PR makes changes to surface errors on the sender/receiver and then falling back on the session instead of always surfacing the error on the session.

## Reference to any github issues
- None
