### PR TITLE
Add tests for session error and close

### DIFF
--- a/lib/session.ts
+++ b/lib/session.ts
@@ -143,9 +143,9 @@ export class Session extends Entity {
    * - **Rejects** the promise with an AmqpError when rhea emits the "session_error" event while trying
    * to close an amqp session.
    */
-  close(): Promise<void> {
-    this.removeAllListeners();
-    return new Promise<void>((resolve, reject) => {
+  async close(): Promise<void> {
+
+    const closePromise = new Promise<void>((resolve, reject) => {
       log.error("[%s] The amqp session '%s' is open ? -> %s", this.connection.id, this.id, this.isOpen());
       if (this.isOpen()) {
         let onError: Func<RheaEventContext, void>;
@@ -203,6 +203,13 @@ export class Session extends Entity {
         return resolve();
       }
     });
+
+    try {
+      await closePromise;
+    } finally {
+      this.removeAllListeners();
+    }
+
   }
 
   /**


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- Add tests for session_close and session_error events based on the patterns used in connection.spec.ts file

In #34, we ensured that all listeners on a link/session are removed when the link/session is closed.
Due to this, the test for session_close was failing as the listener was being removed before session.close() completed.
So, this PR also includes
- move the removing of listeners only after the close() operation is complete instead of doing so in the very beginning
- tests to ensure that we have no listeners attached after the close() operation completes


## Reference to any github issues
- #58
