### PR TITLE
Tests for ensuring event listeners are removed when remove() or close() is called

### DIFF
--- a/lib/link.ts
+++ b/lib/link.ts
@@ -232,8 +232,8 @@ export abstract class Link extends Entity {
   async close(options?: LinkCloseOptions): Promise<void> {
     if (!options) options = {};
     if (options.closeSession == undefined) options.closeSession = true;
-    this.removeAllListeners();
-    await new Promise<void>((resolve, reject) => {
+
+    const closePromise = new Promise<void>((resolve, reject) => {
       log.error("[%s] The %s '%s' on amqp session '%s' is open ? -> %s",
         this.connection.id, this.type, this.name, this.session.id, this.isOpen());
       if (this.isOpen()) {
@@ -299,6 +299,12 @@ export abstract class Link extends Entity {
         return resolve();
       }
     });
+
+    try {
+      await closePromise;
+    } finally {
+      this.removeAllListeners();
+    }
 
     if (options.closeSession) {
       log[this.type]("[%s] %s '%s' has been closed, now closing it's amqp session '%s'.",

--- a/test/receiver.spec.ts
+++ b/test/receiver.spec.ts
@@ -46,15 +46,11 @@ describe("Receiver", () => {
       /** no-op */
     });
 
-    assert.isTrue(receiver.isOpen(), "Receiver should be open.");
     assert.isAtLeast(receiver.listenerCount(rhea.ReceiverEvents.receiverOpen), 1);
 
     receiver.remove();
 
-    // TODO: receiver.isOpen() returns true at this point, need to find out why
-    // assert.isFalse(receiver.isOpen(), "Receiver should not be open.");
     assert.strictEqual(receiver.listenerCount(rhea.ReceiverEvents.receiverOpen), 0);
-
   });
 
   it(".close() removes event listeners", async () => {

--- a/test/receiver.spec.ts
+++ b/test/receiver.spec.ts
@@ -39,4 +39,59 @@ describe("Receiver", () => {
     assert.isTrue(receiver.isItselfClosed(), "Receiver should be fully closed.");
     assert.isFalse(receiver.isOpen(), "Receiver should not be open.");
   });
+
+  it(".remove() removes event listeners", async () => {
+    const receiver = await connection.createReceiver();
+    receiver.on(rhea.ReceiverEvents.receiverOpen, () => {
+      /** no-op */
+    });
+
+    assert.isTrue(receiver.isOpen(), "Receiver should be open.");
+    assert.isAtLeast(receiver.listenerCount(rhea.ReceiverEvents.receiverOpen), 1);
+
+    receiver.remove();
+
+    // TODO: receiver.isOpen() returns true at this point, need to find out why
+    // assert.isFalse(receiver.isOpen(), "Receiver should not be open.");
+    assert.strictEqual(receiver.listenerCount(rhea.ReceiverEvents.receiverOpen), 0);
+
+  });
+
+  it(".close() removes event listeners", async () => {
+    const receiver = await connection.createReceiver();
+    receiver.on(rhea.ReceiverEvents.receiverOpen, () => {
+      /** no-op */
+    });
+
+    assert.isAtLeast(receiver.listenerCount(rhea.ReceiverEvents.receiverOpen), 1);
+
+    await receiver.close();
+
+    assert.strictEqual(receiver.listenerCount(rhea.ReceiverEvents.receiverOpen), 0);
+  });
+
+  // TODO: This test fails because we first get a receiver_open event instead of
+  // a receiver_close event which does get fired, but by then we have removed listeners
+  // it("createReceiver() bubbles up error", async () => {
+  //   const errorCondition = "amqp:connection:forced";
+  //   const errorDescription = "testing error on create";
+  //   mockService.on(
+  //     rhea.SenderEvents.senderOpen,
+  //     (context: rhea.EventContext) => {
+  //       context.sender?.close({
+  //         condition: errorCondition,
+  //         description: errorDescription,
+  //       });
+  //     }
+  //   );
+
+  //   try {
+  //     await connection.createReceiver();
+  //     throw new Error("boo");
+  //   } catch (error) {
+  //     assert.exists(error, "Expected an AMQP error.");
+  //     assert.strictEqual(error.condition, errorCondition);
+  //     assert.strictEqual(error.description, errorDescription);
+  //   }
+  // });
 });

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -92,30 +92,32 @@ describe("Sender", () => {
       assert.strictEqual(error.condition, errorCondition);
       assert.strictEqual(error.description, errorDescription);
     }
-    describe("supports events", () => {
-      it("senderError on sender.close() is bubbled up", async () => {
-        const errorCondition = "amqp:connection:forced";
-        const errorDescription = "testing error on close";
-        mockService.on(
-          rhea.ReceiverEvents.receiverClose,
-          (context: rhea.EventContext) => {
-            context.receiver?.close({
-              condition: errorCondition,
-              description: errorDescription,
-            });
-          }
-        );
+  });
 
-        const sender = await connection.createSender();
-
-        try {
-          await sender.close();
-          throw new Error("boo")
-        } catch (error) {
-          assert.exists(error, "Expected an AMQP error.");
-          assert.strictEqual(error.condition, errorCondition);
-          assert.strictEqual(error.description, errorDescription);
+  describe("supports events", () => {
+    it("senderError on sender.close() is bubbled up", async () => {
+      const errorCondition = "amqp:connection:forced";
+      const errorDescription = "testing error on close";
+      mockService.on(
+        rhea.ReceiverEvents.receiverClose,
+        (context: rhea.EventContext) => {
+          context.receiver?.close({
+            condition: errorCondition,
+            description: errorDescription,
+          });
         }
-      });
+      );
+
+      const sender = await connection.createSender();
+
+      try {
+        await sender.close();
+        throw new Error("boo")
+      } catch (error) {
+        assert.exists(error, "Expected an AMQP error.");
+        assert.strictEqual(error.condition, errorCondition);
+        assert.strictEqual(error.description, errorDescription);
+      }
     });
   });
+});

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -46,15 +46,11 @@ describe("Sender", () => {
       /** no-op */
     });
 
-    assert.isTrue(sender.isOpen(), "Sender should be open.");
     assert.isAtLeast(sender.listenerCount(rhea.SenderEvents.senderOpen), 1);
 
     sender.remove();
 
-    // TODO: sender.isOpen() returns true at this point, need to find out why
-    // assert.isFalse(sender.isOpen(), "Sender should not be open.");
     assert.strictEqual(sender.listenerCount(rhea.SenderEvents.senderOpen), 0);
-
   });
 
   it(".close() removes event listeners", async () => {


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
This PR adds the below tests
- remove() and close() on senders and receivers should remove all event listeners. This refactors the code that was added in #34 to ensure that the removal happens after close() completes
- refactored a session test to move the test on event listeners being removed to match the test files for sender & receiver

extra:
- error when creating sender bubbles up via the promise returned by createSender(). The same for createReceiver() is added but commented due to unexpected behavior which needs further investigation


# Reference to any github issues
- #58
