### PR TITLE
Add cancellation support to all async operations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-### 1.0.1 - #Unreleased
-- Added a `timeoutInSeconds` parameter to the `send` method on the `AwaitableSender`.
+### 1.1.0 - #Unreleased
+- All async methods now take a signal that can be used to cancel the operation. Fixes [#48](https://github.com/amqp/rhea-promise/issues/48)
+- Added a `timeoutInSeconds` parameter to the `send` method on the `AwaitableSender` that overrides the timeout value for the send operation set when creating the sender.
 
 ### 1.0.0 - 2019-06-27
 - Updated minimum version of `rhea` to `^1.0.8`.

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -42,6 +42,20 @@ export interface AwaitableSenderOptions extends BaseSenderOptions {
   sendTimeoutInSeconds?: number;
 }
 
+export interface AwaitableSendOptions {
+  /**
+   * The duration in which the promise to send the message should complete (resolve/reject).
+   * If it is not completed, then the Promise will be rejected after timeout occurs.
+   * Default: `20 seconds`.
+   */
+  timeoutInSeconds?: number;
+  /**
+   * A signal to cancel the send operation. This does not guarantee that the message will not be
+   * sent. It only stops listening for an acknowledgement from the remote endpoint.
+   */
+  abortSignal?: AbortSignalLike;
+}
+
 /**
  * Describes the sender where one can await on the message being sent.
  * @class AwaitableSender
@@ -171,20 +185,18 @@ export class AwaitableSender extends BaseSender {
    * @param {number} [format] The message format. Specify this if a message with custom format needs
    * to be sent. `0` implies the standard AMQP 1.0 defined format. If no value is provided, then the
    * given message is assumed to be of type Message interface and encoded appropriately.
-   * @param {number} [timeoutInSeconds] If provided, this timeout overrides the `sendTimeoutInSeconds`
-   * that is set when the `AwaitableSender` is created. This timeout represents the duration in which
-   * the promise to send the message should complete (resolve/reject). If not, the Promise will be
-   * rejected after timeout.
-   * @param {AbortSignalLike} abortSignal A signal to cancel the send operation. This does not
-   * guarantee that the message will not be sent. It only stops listening for an acknowledgement from
-   * the remote endpoint.
+   * @param {AwaitableSendOptions} [options] Options to configure the timeout and cancellation for
+   * the send operation.
    * @returns {Promise<Delivery>} Promise<Delivery> The delivery information about the sent message.
    */
-  send(msg: Message | Buffer, tag?: Buffer | string, format?: number, timeoutInSeconds?: number, abortSignal?: AbortSignalLike): Promise<Delivery> {
+  send(msg: Message | Buffer, tag?: Buffer | string, format?: number, options?: AwaitableSendOptions): Promise<Delivery> {
     return new Promise<Delivery>((resolve, reject) => {
       log.sender("[%s] Sender '%s' on amqp session '%s', credit: %d available: %d",
         this.connection.id, this.name, this.session.id, this.credit,
         this.session.outgoing.available());
+
+      const abortSignal = options && options.abortSignal;
+      const timeoutInSeconds = options && options.timeoutInSeconds;
 
       if (abortSignal && abortSignal.aborted) {
         const err = createAbortError("Send request has been cancelled.");

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -207,9 +207,7 @@ export class AwaitableSender extends BaseSender {
         };
 
         const removeAbortListener = () => {
-          if (abortSignal) {
-            abortSignal.removeEventListener("abort", onAbort);
-          }
+          abortSignal?.removeEventListener("abort", onAbort);
         };
 
         const delivery = (this._link as RheaSender).send(msg, tag, format);

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -199,17 +199,19 @@ export class AwaitableSender extends BaseSender {
         }, this.sendTimeoutInSeconds * 1000);
 
         const onAbort = () => {
-          const promise = this.deliveryDispositionMap.get(delivery.id) as PromiseLike;
-          clearTimeout(promise.timer);
-          const deleteResult = this.deliveryDispositionMap.delete(delivery.id);
-          log.sender(
-            "[%s] Event: 'abort', Successfully deleted the delivery with id %d from the " +
-            " map of sender '%s' on amqp session '%s' and cleared the timer: %s.",
-            this.connection.id, delivery.id, this.name, this.session.id, deleteResult
-          );
-          const err = createAbortError("Send request has been cancelled.");
-          log.error("[%s] %s", this.connection.id, err.message);
-          promise.reject(err);
+          if (this.deliveryDispositionMap.has(delivery.id)) {
+            const promise = this.deliveryDispositionMap.get(delivery.id) as PromiseLike;
+            clearTimeout(promise.timer);
+            const deleteResult = this.deliveryDispositionMap.delete(delivery.id);
+            log.sender(
+              "[%s] Event: 'abort', Successfully deleted the delivery with id %d from the " +
+              " map of sender '%s' on amqp session '%s' and cleared the timer: %s.",
+              this.connection.id, delivery.id, this.name, this.session.id, deleteResult
+            );
+            const err = createAbortError("Send request has been cancelled.");
+            log.error("[%s] %s", this.connection.id, err.message);
+            promise.reject(err);
+          }
         };
 
         const removeAbortListener = () => {

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -182,7 +182,7 @@ export class AwaitableSender extends BaseSender {
         this.connection.id, this.name, this.session.id, this.credit,
         this.session.outgoing.available());
 
-      if (abortSignal?.aborted) {
+      if (abortSignal && abortSignal.aborted) {
         const err = createAbortError("Send request has been cancelled.");
         log.error("[%s] %s", this.connection.id, err.message);
         return reject(err);
@@ -215,7 +215,7 @@ export class AwaitableSender extends BaseSender {
         };
 
         const removeAbortListener = () => {
-          abortSignal?.removeEventListener("abort", onAbort);
+          if (abortSignal) { abortSignal.removeEventListener("abort", onAbort); }
         };
 
         const delivery = (this._link as RheaSender).send(msg, tag, format);
@@ -231,7 +231,7 @@ export class AwaitableSender extends BaseSender {
           timer: timer
         });
 
-        abortSignal?.addEventListener("abort", onAbort);
+        if (abortSignal) { abortSignal.addEventListener("abort", onAbort); }
       } else {
         // Please send the message after some time.
         const msg =

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -12,7 +12,7 @@ import { Session } from "./session";
 import {
   OperationTimeoutError, InsufficientCreditError, SendOperationFailedError
 } from "./errorDefinitions";
-import { AbortSignalLike, abortErrorName } from "./util/utils";
+import { AbortSignalLike, createAbortError } from "./util/utils";
 
 /**
  * Describes the interface for the send operation Promise which contains a reference to resolve,
@@ -200,8 +200,7 @@ export class AwaitableSender extends BaseSender {
             " map of sender '%s' on amqp session '%s' and cleared the timer: %s.",
             this.connection.id, delivery.id, this.name, this.session.id, deleteResult
           );
-          const err = new Error("Send request has been cancelled.");
-          err.name = abortErrorName;
+          const err = createAbortError("Send request has been cancelled.");
           log.error("[%s] %s", this.connection.id, err.message);
           promise.reject(err);
         };

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -23,7 +23,6 @@ export interface PromiseLike {
   resolve: (value?: any) => void;
   reject: (reason?: any) => void;
   timer: NodeJS.Timer;
-  onAbort: () => void;
 }
 
 /**
@@ -223,8 +222,7 @@ export class AwaitableSender extends BaseSender {
             reject(reason);
             removeAbortListener();
           },
-          timer: timer,
-          onAbort
+          timer: timer
         });
 
         if (abortSignal) {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -9,7 +9,7 @@ import { Sender, SenderOptions } from "./sender";
 import { Receiver, ReceiverOptions } from "./receiver";
 import { Container } from "./container";
 import { defaultOperationTimeoutInSeconds } from "./util/constants";
-import { Func, EmitParameters, emitEvent } from "./util/utils";
+import { Func, EmitParameters, emitEvent, AbortSignalLike, abortErrorName } from "./util/utils";
 import {
   ConnectionEvents, SessionEvents, SenderEvents, ReceiverEvents, create_connection, websocket_connect,
   ConnectionOptions as RheaConnectionOptions, Connection as RheaConnection, AmqpError, Dictionary,
@@ -264,17 +264,19 @@ export class Connection extends Entity {
 
   /**
    * Creates a new amqp connection.
+   * @param abortSignal A signal used to cancel the operation.
    * @return {Promise<Connection>} Promise<Connection>
    * - **Resolves** the promise with the Connection object when rhea emits the "connection_open" event.
    * - **Rejects** the promise with an AmqpError when rhea emits the "connection_close" event
-   * while trying to establish an amqp connection.
+   * while trying to establish an amqp connection or with an AbortError if the operation was cancelled.
    */
-  open(): Promise<Connection> {
+  open(abortSignal?: AbortSignalLike): Promise<Connection> {
     return new Promise((resolve, reject) => {
       if (!this.isOpen()) {
 
         let onOpen: Func<RheaEventContext, void>;
         let onClose: Func<RheaEventContext, void>;
+        let onAbort: Func<void, void>;
         let waitTimer: any;
 
         const removeListeners: Function = () => {
@@ -283,6 +285,9 @@ export class Connection extends Entity {
           this._connection.removeListener(ConnectionEvents.connectionOpen, onOpen);
           this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
           this._connection.removeListener(ConnectionEvents.disconnected, onClose);
+          if (abortSignal) {
+            abortSignal.removeEventListener("abort", onAbort);
+          }
         };
 
         onOpen = (context: RheaEventContext) => {
@@ -296,6 +301,15 @@ export class Connection extends Entity {
           const err = context.error || context.connection.error || Error('Failed to connect');
           log.error("[%s] Error occurred while establishing amqp connection: %O",
             this.id, err);
+          return reject(err);
+        };
+
+        onAbort = () => {
+          removeListeners();
+          this._connection.close();
+          const err = new Error("Connection open request has been cancelled.");
+          err.name = abortErrorName;
+          log.error(`[%s] ${err.message}`);
           return reject(err);
         };
 
@@ -314,6 +328,14 @@ export class Connection extends Entity {
         log.connection("[%s] Trying to create a new amqp connection.", this.id);
         this._connection.connect();
         this.actionInitiated++;
+
+        if (abortSignal) {
+          if (abortSignal.aborted) {
+            onAbort();
+          } else {
+            abortSignal.addEventListener("abort", onAbort);
+          }
+        }
       } else {
         return resolve(this);
       }
@@ -323,25 +345,33 @@ export class Connection extends Entity {
 
   /**
    * Closes the amqp connection.
+   * @param abortSignal A signal used to cancel the operation. The local endpoint is indeed closed.
+   * This does not guarantee that the remote has closed as well. It only stops listening for
+   * an acknowledgement that the remote endpoint is closed as well.
    * @return {Promise<void>} Promise<void>
    * - **Resolves** the promise when rhea emits the "connection_close" event.
    * - **Rejects** the promise with an AmqpError when rhea emits the "connection_error" event while
-   * trying to close an amqp connection.
+   * trying to close an amqp connection or with an AbortError if the operation was cancelled.
    */
-  close(): Promise<void> {
+  close(abortSignal?: AbortSignalLike): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       log.error("[%s] The connection is open ? -> %s", this.id, this.isOpen());
       if (this.isOpen()) {
         let onClose: Func<RheaEventContext, void>;
         let onError: Func<RheaEventContext, void>;
         let onDisconnected: Func<RheaEventContext, void>;
+        let onAbort: Func<void, void>;
         let waitTimer: any;
+
         const removeListeners = () => {
           clearTimeout(waitTimer);
           this.actionInitiated--;
           this._connection.removeListener(ConnectionEvents.connectionError, onError);
           this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
           this._connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
+          if (abortSignal) {
+            abortSignal.removeEventListener("abort", onAbort);
+          }
         };
 
         onClose = (context: RheaEventContext) => {
@@ -366,6 +396,14 @@ export class Connection extends Entity {
           log.error("[%s] Connection got disconnected while closing itself: %O.", this.id, error);
         };
 
+        onAbort = () => {
+          removeListeners();
+          const err = new Error("Connection close request has been cancelled.");
+          err.name = abortErrorName;
+          log.error(`[%s] ${err.message}`);
+          return reject(err);
+        };
+
         const actionAfterTimeout = () => {
           removeListeners();
           const msg: string = `Unable to close the amqp connection "${this.id}" due to operation timeout.`;
@@ -380,6 +418,14 @@ export class Connection extends Entity {
         waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
         this._connection.close();
         this.actionInitiated++;
+
+        if (abortSignal) {
+          if (abortSignal.aborted) {
+            onAbort();
+          } else {
+            abortSignal.addEventListener("abort", onAbort);
+          }
+        }
       } else {
         return resolve();
       }
@@ -452,12 +498,13 @@ export class Connection extends Entity {
 
   /**
    * Creates an amqp session on the provided amqp connection.
+   * @param abortSignal A signal used to cancel the operation.
    * @return {Promise<Session>} Promise<Session>
    * - **Resolves** the promise with the Session object when rhea emits the "session_open" event.
    * - **Rejects** the promise with an AmqpError when rhea emits the "session_close" event while
-   * trying to create an amqp session.
+   * trying to create an amqp session or with an AbortError if the operation was cancelled.
    */
-  createSession(): Promise<Session> {
+  createSession(abortSignal?: AbortSignalLike): Promise<Session> {
     return new Promise((resolve, reject) => {
       const rheaSession = this._connection.create_session();
       const session = new Session(this, rheaSession);
@@ -465,6 +512,7 @@ export class Connection extends Entity {
       let onOpen: Func<RheaEventContext, void>;
       let onClose: Func<RheaEventContext, void>;
       let onDisconnected: Func<RheaEventContext, void>;
+      let onAbort: Func<void, void>;
       let waitTimer: any;
 
       const removeListeners = () => {
@@ -473,6 +521,9 @@ export class Connection extends Entity {
         rheaSession.removeListener(SessionEvents.sessionOpen, onOpen);
         rheaSession.removeListener(SessionEvents.sessionClose, onClose);
         rheaSession.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
+        if (abortSignal) {
+          abortSignal.removeEventListener("abort", onAbort);
+        }
       };
 
       onOpen = (context: RheaEventContext) => {
@@ -498,6 +549,15 @@ export class Connection extends Entity {
         return reject(error);
       };
 
+      onAbort = () => {
+        removeListeners();
+        rheaSession.close();
+        const err = new Error("Create session request has been cancelled.");
+        err.name = abortErrorName;
+        log.error(`[%s] ${err.message}`);
+        return reject(err);
+      };
+
       const actionAfterTimeout = () => {
         removeListeners();
         const msg: string = `Unable to create the amqp session due to operation timeout.`;
@@ -512,19 +572,30 @@ export class Connection extends Entity {
       log.session("[%s] Calling amqp session.begin().", this.id);
       waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
       rheaSession.begin();
+
+      if (abortSignal) {
+        if (abortSignal.aborted) {
+          onAbort();
+        } else {
+          abortSignal.addEventListener("abort", onAbort);
+        }
+      }
     });
   }
 
   /**
    * Creates an amqp sender link. It either uses the provided session or creates a new one.
+   * - **Resolves** the promise with the Sender object when rhea emits the "sender_open" event.
+   * - **Rejects** the promise with an AmqpError when rhea emits the "sender_close" event while
+   * trying to create an amqp session or with an AbortError if the operation was cancelled.
    * @param {SenderOptionsWithSession} options Optional parameters to create a sender link.
    * @return {Promise<Sender>} Promise<Sender>.
    */
-  async createSender(options?: SenderOptionsWithSession): Promise<Sender> {
+  async createSender(options?: SenderOptionsWithSession & { abortSignal?: AbortSignalLike; }): Promise<Sender> {
     if (options && options.session && options.session.createSender) {
       return options.session.createSender(options);
     }
-    const session = await this.createSession();
+    const session = await this.createSession(options?.abortSignal);
     return session.createSender(options);
   }
 
@@ -540,24 +611,27 @@ export class Connection extends Entity {
    *
    * @return Promise<AwaitableSender>.
    */
-  async createAwaitableSender(options?: AwaitableSenderOptionsWithSession): Promise<AwaitableSender> {
+  async createAwaitableSender(options?: AwaitableSenderOptionsWithSession & { abortSignal?: AbortSignalLike; }): Promise<AwaitableSender> {
     if (options && options.session && options.session.createAwaitableSender) {
       return options.session.createAwaitableSender(options);
     }
-    const session = await this.createSession();
+    const session = await this.createSession(options?.abortSignal);
     return session.createAwaitableSender(options);
   }
 
   /**
    * Creates an amqp receiver link. It either uses the provided session or creates a new one.
+   * - **Resolves** the promise with the Sender object when rhea emits the "receiver_open" event.
+   * - **Rejects** the promise with an AmqpError when rhea emits the "receiver_close" event while
+   * trying to create an amqp session or with an AbortError if the operation was cancelled.
    * @param {ReceiverOptionsWithSession} options Optional parameters to create a receiver link.
    * @return {Promise<Receiver>} Promise<Receiver>.
    */
-  async createReceiver(options?: ReceiverOptionsWithSession): Promise<Receiver> {
+  async createReceiver(options?: ReceiverOptionsWithSession & { abortSignal?: AbortSignalLike; }): Promise<Receiver> {
     if (options && options.session && options.session.createReceiver) {
       return options.session.createReceiver(options);
     }
-    const session = await this.createSession();
+    const session = await this.createSession(options?.abortSignal);
     return session.createReceiver(options);
   }
 
@@ -572,17 +646,17 @@ export class Connection extends Entity {
    * @return {Promise<ReqResLink>} Promise<ReqResLink>
    */
   async createRequestResponseLink(senderOptions: SenderOptions, receiverOptions: ReceiverOptions,
-    providedSession?: Session): Promise<ReqResLink> {
+    providedSession?: Session, abortSignal?: AbortSignal): Promise<ReqResLink> {
     if (!senderOptions) {
       throw new Error(`Please provide sender options.`);
     }
     if (!receiverOptions) {
       throw new Error(`Please provide receiver options.`);
     }
-    const session = providedSession || await this.createSession();
+    const session = providedSession || await this.createSession(abortSignal);
     const [sender, receiver] = await Promise.all([
-      session.createSender(senderOptions),
-      session.createReceiver(receiverOptions)
+      session.createSender({ ...senderOptions, abortSignal }),
+      session.createReceiver({ ...receiverOptions, abortSignal })
     ]);
     log.connection("[%s] Successfully created the sender '%s' and receiver '%s' on the same " +
       "amqp session '%s'.", this.id, sender.name, receiver.name, session.id);

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -357,13 +357,12 @@ export class Connection extends Entity {
         this._connection.connect();
         this.actionInitiated++;
 
-        if (abortSignal) {
-          if (abortSignal.aborted) {
-            onAbort();
-          } else {
-            abortSignal.addEventListener("abort", onAbort);
-          }
+        if (abortSignal?.aborted) {
+          onAbort();
+        } else {
+          abortSignal?.addEventListener("abort", onAbort);
         }
+
       } else {
         return resolve(this);
       }
@@ -446,12 +445,10 @@ export class Connection extends Entity {
         this._connection.close();
         this.actionInitiated++;
 
-        if (abortSignal) {
-          if (abortSignal.aborted) {
-            onAbort();
-          } else {
-            abortSignal.addEventListener("abort", onAbort);
-          }
+        if (abortSignal?.aborted) {
+          onAbort();
+        } else {
+          abortSignal?.addEventListener("abort", onAbort);
         }
       } else {
         return resolve();
@@ -598,12 +595,11 @@ export class Connection extends Entity {
       waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
       rheaSession.begin();
 
-      if (abortSignal) {
-        if (abortSignal.aborted) {
-          onAbort();
-        } else {
-          abortSignal.addEventListener("abort", onAbort);
-        }
+
+      if (abortSignal?.aborted) {
+        onAbort();
+      } else {
+        abortSignal?.addEventListener("abort", onAbort);
       }
     });
   }

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -307,7 +307,7 @@ export class Connection extends Entity {
         let onOpen: Func<RheaEventContext, void>;
         let onClose: Func<RheaEventContext, void>;
         let onAbort: Func<void, void>;
-        const abortSignal = options?.abortSignal;
+        const abortSignal = options && options.abortSignal;
         let waitTimer: any;
 
         const removeListeners: Function = () => {
@@ -316,7 +316,7 @@ export class Connection extends Entity {
           this._connection.removeListener(ConnectionEvents.connectionOpen, onOpen);
           this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
           this._connection.removeListener(ConnectionEvents.disconnected, onClose);
-          abortSignal?.removeEventListener("abort", onAbort);
+          if (abortSignal) { abortSignal.removeEventListener("abort", onAbort); }
         };
 
         onOpen = (context: RheaEventContext) => {
@@ -357,12 +357,13 @@ export class Connection extends Entity {
         this._connection.connect();
         this.actionInitiated++;
 
-        if (abortSignal?.aborted) {
-          onAbort();
-        } else {
-          abortSignal?.addEventListener("abort", onAbort);
+        if (abortSignal) {
+          if (abortSignal.aborted) {
+            onAbort();
+          } else {
+            abortSignal.addEventListener("abort", onAbort);
+          }
         }
-
       } else {
         return resolve(this);
       }
@@ -389,7 +390,7 @@ export class Connection extends Entity {
         let onError: Func<RheaEventContext, void>;
         let onDisconnected: Func<RheaEventContext, void>;
         let onAbort: Func<void, void>;
-        const abortSignal = options?.abortSignal;
+        const abortSignal = options && options.abortSignal;
         let waitTimer: any;
 
         const removeListeners = () => {
@@ -398,7 +399,7 @@ export class Connection extends Entity {
           this._connection.removeListener(ConnectionEvents.connectionError, onError);
           this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
           this._connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-          abortSignal?.removeEventListener("abort", onAbort);
+          if (abortSignal) { abortSignal.removeEventListener("abort", onAbort); }
         };
 
         onClose = (context: RheaEventContext) => {
@@ -445,10 +446,12 @@ export class Connection extends Entity {
         this._connection.close();
         this.actionInitiated++;
 
-        if (abortSignal?.aborted) {
-          onAbort();
-        } else {
-          abortSignal?.addEventListener("abort", onAbort);
+        if (abortSignal) {
+          if (abortSignal.aborted) {
+            onAbort();
+          } else {
+            abortSignal.addEventListener("abort", onAbort);
+          }
         }
       } else {
         return resolve();
@@ -537,7 +540,7 @@ export class Connection extends Entity {
       let onClose: Func<RheaEventContext, void>;
       let onDisconnected: Func<RheaEventContext, void>;
       let onAbort: Func<void, void>;
-      const abortSignal = options?.abortSignal;
+      const abortSignal = options && options.abortSignal;
       let waitTimer: any;
 
       const removeListeners = () => {
@@ -546,7 +549,7 @@ export class Connection extends Entity {
         rheaSession.removeListener(SessionEvents.sessionOpen, onOpen);
         rheaSession.removeListener(SessionEvents.sessionClose, onClose);
         rheaSession.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-        abortSignal?.removeEventListener("abort", onAbort);
+        if (abortSignal) { abortSignal.removeEventListener("abort", onAbort); }
       };
 
       onOpen = (context: RheaEventContext) => {
@@ -595,11 +598,12 @@ export class Connection extends Entity {
       waitTimer = setTimeout(actionAfterTimeout, this.options!.operationTimeoutInSeconds! * 1000);
       rheaSession.begin();
 
-
-      if (abortSignal?.aborted) {
-        onAbort();
-      } else {
-        abortSignal?.addEventListener("abort", onAbort);
+      if (abortSignal) {
+        if (abortSignal.aborted) {
+          onAbort();
+        } else {
+          abortSignal.addEventListener("abort", onAbort);
+        }
       }
     });
   }
@@ -616,7 +620,7 @@ export class Connection extends Entity {
     if (options && options.session && options.session.createSender) {
       return options.session.createSender(options);
     }
-    const session = await this.createSession({ abortSignal: options?.abortSignal });
+    const session = await this.createSession({ abortSignal: options && options.abortSignal });
     return session.createSender(options);
   }
 
@@ -636,7 +640,7 @@ export class Connection extends Entity {
     if (options && options.session && options.session.createAwaitableSender) {
       return options.session.createAwaitableSender(options);
     }
-    const session = await this.createSession({ abortSignal: options?.abortSignal });
+    const session = await this.createSession({ abortSignal: options && options.abortSignal });
     return session.createAwaitableSender(options);
   }
 
@@ -652,7 +656,7 @@ export class Connection extends Entity {
     if (options && options.session && options.session.createReceiver) {
       return options.session.createReceiver(options);
     }
-    const session = await this.createSession({ abortSignal: options?.abortSignal });
+    const session = await this.createSession({ abortSignal: options && options.abortSignal });
     return session.createReceiver(options);
   }
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -49,6 +49,20 @@ export interface ReceiverOptionsWithSession extends ReceiverOptions {
 }
 
 /**
+ * Set of options to use when running Connection.open()
+ */
+export interface ConnectionOpenOptions {
+  abortSignal?: AbortSignalLike;
+}
+
+/**
+ * Set of options to use when running Connection.close()
+ */
+export interface ConnectionCloseOptions {
+  abortSignal?: AbortSignalLike;
+}
+
+/**
  * Describes the options that can be provided while creating an AMQP connection.
  * @interface ConnectionOptions
  */
@@ -264,19 +278,20 @@ export class Connection extends Entity {
 
   /**
    * Creates a new amqp connection.
-   * @param abortSignal A signal used to cancel the operation.
+   * @param options A set of options including a signal used to cancel the operation.
    * @return {Promise<Connection>} Promise<Connection>
    * - **Resolves** the promise with the Connection object when rhea emits the "connection_open" event.
    * - **Rejects** the promise with an AmqpError when rhea emits the "connection_close" event
    * while trying to establish an amqp connection or with an AbortError if the operation was cancelled.
    */
-  open(abortSignal?: AbortSignalLike): Promise<Connection> {
+  open(options?: ConnectionOpenOptions): Promise<Connection> {
     return new Promise((resolve, reject) => {
       if (!this.isOpen()) {
 
         let onOpen: Func<RheaEventContext, void>;
         let onClose: Func<RheaEventContext, void>;
         let onAbort: Func<void, void>;
+        const abortSignal = options?.abortSignal;
         let waitTimer: any;
 
         const removeListeners: Function = () => {
@@ -345,7 +360,8 @@ export class Connection extends Entity {
 
   /**
    * Closes the amqp connection.
-   * @param abortSignal A signal used to cancel the operation. The local endpoint is indeed closed.
+   * @param options A set of options including a signal used to cancel the operation.
+   * When the abort signal is used, the local endpoint is indeed closed.
    * This does not guarantee that the remote has closed as well. It only stops listening for
    * an acknowledgement that the remote endpoint is closed as well.
    * @return {Promise<void>} Promise<void>
@@ -353,7 +369,7 @@ export class Connection extends Entity {
    * - **Rejects** the promise with an AmqpError when rhea emits the "connection_error" event while
    * trying to close an amqp connection or with an AbortError if the operation was cancelled.
    */
-  close(abortSignal?: AbortSignalLike): Promise<void> {
+  close(options?: ConnectionCloseOptions): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       log.error("[%s] The connection is open ? -> %s", this.id, this.isOpen());
       if (this.isOpen()) {
@@ -361,6 +377,7 @@ export class Connection extends Entity {
         let onError: Func<RheaEventContext, void>;
         let onDisconnected: Func<RheaEventContext, void>;
         let onAbort: Func<void, void>;
+        const abortSignal = options?.abortSignal;
         let waitTimer: any;
 
         const removeListeners = () => {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -374,7 +374,7 @@ export class Connection extends Entity {
   /**
    * Closes the amqp connection.
    * @param options A set of options including a signal used to cancel the operation.
-   * When the abort signal is used, the local endpoint is indeed closed.
+   * When the abort signal in the options is fired, the local endpoint is closed.
    * This does not guarantee that the remote has closed as well. It only stops listening for
    * an acknowledgement that the remote endpoint is closed as well.
    * @return {Promise<void>} Promise<void>

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -9,7 +9,7 @@ import { Sender, SenderOptions } from "./sender";
 import { Receiver, ReceiverOptions } from "./receiver";
 import { Container } from "./container";
 import { defaultOperationTimeoutInSeconds } from "./util/constants";
-import { Func, EmitParameters, emitEvent, AbortSignalLike, abortErrorName } from "./util/utils";
+import { Func, EmitParameters, emitEvent, AbortSignalLike, createAbortError } from "./util/utils";
 import {
   ConnectionEvents, SessionEvents, SenderEvents, ReceiverEvents, create_connection, websocket_connect,
   ConnectionOptions as RheaConnectionOptions, Connection as RheaConnection, AmqpError, Dictionary,
@@ -336,9 +336,8 @@ export class Connection extends Entity {
         onAbort = () => {
           removeListeners();
           this._connection.close();
-          const err = new Error("Connection open request has been cancelled.");
-          err.name = abortErrorName;
-          log.error(`[%s] ${err.message}`);
+          const err = createAbortError("Connection open request has been cancelled.");
+          log.error("[%s] [%s]", this.id, err.message);
           return reject(err);
         };
 
@@ -427,9 +426,8 @@ export class Connection extends Entity {
 
         onAbort = () => {
           removeListeners();
-          const err = new Error("Connection close request has been cancelled.");
-          err.name = abortErrorName;
-          log.error(`[%s] ${err.message}`);
+          const err = createAbortError("Connection close request has been cancelled.");
+          log.error("[%s] [%s]", this.id, err.message);
           return reject(err);
         };
 
@@ -580,9 +578,8 @@ export class Connection extends Entity {
       onAbort = () => {
         removeListeners();
         rheaSession.close();
-        const err = new Error("Create session request has been cancelled.");
-        err.name = abortErrorName;
-        log.error(`[%s] ${err.message}`);
+        const err = createAbortError("Create session request has been cancelled.");
+        log.error("[%s] [%s]", this.id, err.message);
         return reject(err);
       };
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -316,9 +316,7 @@ export class Connection extends Entity {
           this._connection.removeListener(ConnectionEvents.connectionOpen, onOpen);
           this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
           this._connection.removeListener(ConnectionEvents.disconnected, onClose);
-          if (abortSignal) {
-            abortSignal.removeEventListener("abort", onAbort);
-          }
+          abortSignal?.removeEventListener("abort", onAbort);
         };
 
         onOpen = (context: RheaEventContext) => {
@@ -402,9 +400,7 @@ export class Connection extends Entity {
           this._connection.removeListener(ConnectionEvents.connectionError, onError);
           this._connection.removeListener(ConnectionEvents.connectionClose, onClose);
           this._connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-          if (abortSignal) {
-            abortSignal.removeEventListener("abort", onAbort);
-          }
+          abortSignal?.removeEventListener("abort", onAbort);
         };
 
         onClose = (context: RheaEventContext) => {
@@ -555,9 +551,7 @@ export class Connection extends Entity {
         rheaSession.removeListener(SessionEvents.sessionOpen, onOpen);
         rheaSession.removeListener(SessionEvents.sessionClose, onClose);
         rheaSession.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-        if (abortSignal) {
-          abortSignal.removeEventListener("abort", onAbort);
-        }
+        abortSignal?.removeEventListener("abort", onAbort);
       };
 
       onOpen = (context: RheaEventContext) => {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -671,7 +671,7 @@ export class Connection extends Entity {
    * @return {Promise<ReqResLink>} Promise<ReqResLink>
    */
   async createRequestResponseLink(senderOptions: SenderOptions, receiverOptions: ReceiverOptions,
-    providedSession?: Session, abortSignal?: AbortSignal): Promise<ReqResLink> {
+    providedSession?: Session, abortSignal?: AbortSignalLike): Promise<ReqResLink> {
     if (!senderOptions) {
       throw new Error(`Please provide sender options.`);
     }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -146,7 +146,7 @@ export class Session extends Entity {
    * Closes the underlying amqp session in rhea if open. Also removes all the event
    * handlers added in the rhea-promise library on the session
    * @param options A set of options including a signal used to cancel the operation.
-   * When the abort signal is used, the local endpoint is indeed closed.
+   * When the abort signal in the options is fired, the local endpoint is closed.
    * This does not guarantee that the remote has closed as well. It only stops listening for
    * an acknowledgement that the remote endpoint is closed as well.
    * @return {Promise<void>} Promise<void>

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -163,7 +163,7 @@ export class Session extends Entity {
         let onClose: Func<RheaEventContext, void>;
         let onDisconnected: Func<RheaEventContext, void>;
         let onAbort: Func<void, void>;
-        const abortSignal = options?.abortSignal;
+        const abortSignal = options && options.abortSignal;
         let waitTimer: any;
 
         const removeListeners = () => {
@@ -172,7 +172,7 @@ export class Session extends Entity {
           this._session.removeListener(SessionEvents.sessionError, onError);
           this._session.removeListener(SessionEvents.sessionClose, onClose);
           this._session.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-          abortSignal?.removeEventListener("abort", onAbort);
+          if (abortSignal) { abortSignal.removeEventListener("abort", onAbort); }
         };
 
         onClose = (context: RheaEventContext) => {
@@ -221,10 +221,12 @@ export class Session extends Entity {
         this._session.close();
         this.actionInitiated++;
 
-        if (abortSignal?.aborted) {
-          onAbort();
-        } else {
-          abortSignal?.addEventListener("abort", onAbort);
+        if (abortSignal) {
+          if (abortSignal.aborted) {
+            onAbort();
+          } else {
+            abortSignal.addEventListener("abort", onAbort);
+          }
         }
       } else {
         return resolve();
@@ -290,7 +292,7 @@ export class Session extends Entity {
       let onClose: Func<RheaEventContext, void>;
       let onDisconnected: Func<RheaEventContext, void>;
       let onAbort: Func<void, void>;
-      const abortSignal = options?.abortSignal;
+      const abortSignal = options && options.abortSignal;
       let waitTimer: any;
 
       if (options && options.onMessage) {
@@ -322,7 +324,7 @@ export class Session extends Entity {
         rheaReceiver.removeListener(ReceiverEvents.receiverOpen, onOpen);
         rheaReceiver.removeListener(ReceiverEvents.receiverClose, onClose);
         rheaReceiver.session.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-        abortSignal?.removeEventListener("abort", onAbort);
+        if (abortSignal) { abortSignal.removeEventListener("abort", onAbort); }
       };
 
       onOpen = (context: RheaEventContext) => {
@@ -372,10 +374,12 @@ export class Session extends Entity {
       rheaReceiver.session.connection.on(ConnectionEvents.disconnected, onDisconnected);
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
 
-      if (abortSignal?.aborted) {
-        onAbort();
-      } else {
-        abortSignal?.addEventListener("abort", onAbort);
+      if (abortSignal) {
+        if (abortSignal.aborted) {
+          onAbort();
+        } else {
+          abortSignal.addEventListener("abort", onAbort);
+        }
       }
     });
   }
@@ -446,7 +450,7 @@ export class Session extends Entity {
       let onClose: Func<RheaEventContext, void>;
       let onDisconnected: Func<RheaEventContext, void>;
       let onAbort: Func<void, void>;
-      const abortSignal = options?.abortSignal;
+      const abortSignal = options && options.abortSignal;
       let waitTimer: any;
 
       // listeners provided by the user in the options object should be added
@@ -480,7 +484,7 @@ export class Session extends Entity {
         rheaSender.removeListener(SenderEvents.senderOpen, onSendable);
         rheaSender.removeListener(SenderEvents.senderClose, onClose);
         rheaSender.session.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-        abortSignal?.removeEventListener("abort", onAbort);
+        if (abortSignal) { abortSignal.removeEventListener("abort", onAbort); }
       };
 
       onSendable = (context: RheaEventContext) => {
@@ -530,10 +534,12 @@ export class Session extends Entity {
       rheaSender.session.connection.on(ConnectionEvents.disconnected, onDisconnected);
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
 
-      if (abortSignal?.aborted) {
-        onAbort();
-      } else {
-        abortSignal?.addEventListener("abort", onAbort);
+      if (abortSignal) {
+        if (abortSignal.aborted) {
+          onAbort();
+        } else {
+          abortSignal.addEventListener("abort", onAbort);
+        }
       }
     });
   }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -9,7 +9,7 @@ import {
   SenderEvents, ReceiverEvents, SessionEvents, AmqpError, Session as RheaSession,
   EventContext as RheaEventContext, ConnectionEvents
 } from "rhea";
-import { Func, EmitParameters, emitEvent, abortErrorName, AbortSignalLike } from "./util/utils";
+import { Func, EmitParameters, emitEvent, createAbortError, AbortSignalLike } from "./util/utils";
 import { OnAmqpEvent } from "./eventContext";
 import { Entity } from "./entity";
 import { OperationTimeoutError } from "./errorDefinitions";
@@ -200,9 +200,8 @@ export class Session extends Entity {
 
         onAbort = () => {
           removeListeners();
-          const err = new Error("Session close request has been cancelled.");
-          err.name = abortErrorName;
-          log.error(`[%s] ${err.message}`);
+          const err = createAbortError("Session close request has been cancelled.");
+          log.error("[%s] [%s]", this.connection.id, err.message);
           return reject(err);
         };
 
@@ -356,9 +355,8 @@ export class Session extends Entity {
       onAbort = () => {
         removeListeners();
         rheaReceiver.close();
-        const err = new Error("Create receiver request has been cancelled.");
-        err.name = abortErrorName;
-        log.error(`[%s] ${err.message}`);
+        const err = createAbortError("Create receiver request has been cancelled.");
+        log.error("[%s] [%s]", this.connection.id, err.message);
         return reject(err);
       };
 
@@ -517,9 +515,8 @@ export class Session extends Entity {
       onAbort = () => {
         removeListeners();
         rheaSender.close();
-        const err = new Error("Create sender request has been cancelled.");
-        err.name = abortErrorName;
-        log.error(`[%s] ${err.message}`);
+        const err = createAbortError("Create sender request has been cancelled.");
+        log.error("[%s] [%s]", this.connection.id, err.message);
         return reject(err);
       };
 

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -221,12 +221,10 @@ export class Session extends Entity {
         this._session.close();
         this.actionInitiated++;
 
-        if (abortSignal) {
-          if (abortSignal.aborted) {
-            onAbort();
-          } else {
-            abortSignal.addEventListener("abort", onAbort);
-          }
+        if (abortSignal?.aborted) {
+          onAbort();
+        } else {
+          abortSignal?.addEventListener("abort", onAbort);
         }
       } else {
         return resolve();
@@ -374,12 +372,10 @@ export class Session extends Entity {
       rheaReceiver.session.connection.on(ConnectionEvents.disconnected, onDisconnected);
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
 
-      if (abortSignal) {
-        if (abortSignal.aborted) {
-          onAbort();
-        } else {
-          abortSignal.addEventListener("abort", onAbort);
-        }
+      if (abortSignal?.aborted) {
+        onAbort();
+      } else {
+        abortSignal?.addEventListener("abort", onAbort);
       }
     });
   }
@@ -534,12 +530,10 @@ export class Session extends Entity {
       rheaSender.session.connection.on(ConnectionEvents.disconnected, onDisconnected);
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
 
-      if (abortSignal) {
-        if (abortSignal.aborted) {
-          onAbort();
-        } else {
-          abortSignal.addEventListener("abort", onAbort);
-        }
+      if (abortSignal?.aborted) {
+        onAbort();
+      } else {
+        abortSignal?.addEventListener("abort", onAbort);
       }
     });
   }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -172,9 +172,7 @@ export class Session extends Entity {
           this._session.removeListener(SessionEvents.sessionError, onError);
           this._session.removeListener(SessionEvents.sessionClose, onClose);
           this._session.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-          if (abortSignal) {
-            abortSignal.removeEventListener("abort", onAbort);
-          }
+          abortSignal?.removeEventListener("abort", onAbort);
         };
 
         onClose = (context: RheaEventContext) => {
@@ -327,9 +325,7 @@ export class Session extends Entity {
         rheaReceiver.removeListener(ReceiverEvents.receiverOpen, onOpen);
         rheaReceiver.removeListener(ReceiverEvents.receiverClose, onClose);
         rheaReceiver.session.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-        if (abortSignal) {
-          abortSignal.removeEventListener("abort", onAbort);
-        }
+        abortSignal?.removeEventListener("abort", onAbort);
       };
 
       onOpen = (context: RheaEventContext) => {
@@ -490,9 +486,7 @@ export class Session extends Entity {
         rheaSender.removeListener(SenderEvents.senderOpen, onSendable);
         rheaSender.removeListener(SenderEvents.senderClose, onClose);
         rheaSender.session.connection.removeListener(ConnectionEvents.disconnected, onDisconnected);
-        if (abortSignal) {
-          abortSignal.removeEventListener("abort", onAbort);
-        }
+        abortSignal?.removeEventListener("abort", onAbort);
       };
 
       onSendable = (context: RheaEventContext) => {

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -24,6 +24,13 @@ export declare interface Session {
 }
 
 /**
+ * Set of options to use when running session.close()
+ */
+export interface SessionCloseOptions {
+  abortSignal?: AbortSignalLike;
+}
+
+/**
  * @internal
  */
 enum SenderType {
@@ -138,7 +145,8 @@ export class Session extends Entity {
   /**
    * Closes the underlying amqp session in rhea if open. Also removes all the event
    * handlers added in the rhea-promise library on the session
-   * @param abortSignal A signal used to cancel the operation. The local endpoint is indeed closed.
+   * @param options A set of options including a signal used to cancel the operation.
+   * When the abort signal is used, the local endpoint is indeed closed.
    * This does not guarantee that the remote has closed as well. It only stops listening for
    * an acknowledgement that the remote endpoint is closed as well.
    * @return {Promise<void>} Promise<void>
@@ -146,7 +154,7 @@ export class Session extends Entity {
    * - **Rejects** the promise with an AmqpError when rhea emits the "session_error" event while trying
    * to close an amqp session or with an AbortError if the operation was cancelled.
    */
-  async close(abortSignal?: AbortSignalLike): Promise<void> {
+  async close(options?: SessionCloseOptions): Promise<void> {
 
     const closePromise = new Promise<void>((resolve, reject) => {
       log.error("[%s] The amqp session '%s' is open ? -> %s", this.connection.id, this.id, this.isOpen());
@@ -155,6 +163,7 @@ export class Session extends Entity {
         let onClose: Func<RheaEventContext, void>;
         let onDisconnected: Func<RheaEventContext, void>;
         let onAbort: Func<void, void>;
+        const abortSignal = options?.abortSignal;
         let waitTimer: any;
 
         const removeListeners = () => {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -222,3 +222,14 @@ export interface AbortSignalLike {
 }
 
 export const abortErrorName = "AbortError";
+
+/**
+ * Helper method to return an Error to be used when an operation is cancelled
+ * using an AbortSignalLike
+ * @param errorMessage
+ */
+export function createAbortError(errorMessage: string): Error {
+  const error = new Error(errorMessage);
+  error.name = abortErrorName;
+  return error;
+}

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -197,3 +197,28 @@ export function emitEvent(params: EmitParameters): void {
     emit();
   }
 }
+
+export interface AbortSignalLike {
+  /**
+   * Indicates if the signal has already been aborted.
+   */
+  readonly aborted: boolean;
+  /**
+   * Add new "abort" event listener, only support "abort" event.
+   */
+  addEventListener(
+    type: "abort",
+    listener: (this: AbortSignalLike, ev: any) => any,
+    options?: any
+  ): void;
+  /**
+   * Remove "abort" event listener, only support "abort" event.
+   */
+  removeEventListener(
+    type: "abort",
+    listener: (this: AbortSignalLike, ev: any) => any,
+    options?: any
+  ): void;
+}
+
+export const abortErrorName = "AbortError";

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "messaging"
   ],
   "devDependencies": {
+    "@azure/abort-controller": "^1.0.1",
     "@types/chai": "^4.2.11",
     "@types/debug": "^0.0.31",
     "@types/dotenv": "^6.1.1",

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -202,7 +202,6 @@ describe("Connection", () => {
       let abortErrorThrown = false;
       try {
         await connectionOpenPromise;
-        abortController.abort();
       } catch (error) {
         abortErrorThrown = error.name === abortErrorName;
       }

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -167,6 +167,7 @@ describe("Connection", () => {
     it("connection.open() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
 
       const abortController = new AbortController();
@@ -190,6 +191,7 @@ describe("Connection", () => {
     it("connection.open() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
 
       const abortController = new AbortController();
@@ -213,6 +215,7 @@ describe("Connection", () => {
     it("connection.close() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
 
       await connection.open();
@@ -240,6 +243,7 @@ describe("Connection", () => {
     it("connection.close() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
 
       await connection.open();
@@ -267,6 +271,7 @@ describe("Connection", () => {
     it("createSession() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -291,6 +296,7 @@ describe("Connection", () => {
     it("createSession() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -315,6 +321,7 @@ describe("Connection", () => {
     it("createSender() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -339,6 +346,7 @@ describe("Connection", () => {
     it("createSender() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -363,6 +371,7 @@ describe("Connection", () => {
     it("createAwaitableSender() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -387,6 +396,7 @@ describe("Connection", () => {
     it("createAwaitableSender() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -411,6 +421,7 @@ describe("Connection", () => {
     it("createReceiver() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -435,6 +446,7 @@ describe("Connection", () => {
     it("createReceiver() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -459,6 +471,7 @@ describe("Connection", () => {
     it("createRequestResponseLink() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 
@@ -483,6 +496,7 @@ describe("Connection", () => {
     it("createRequestResponseLink() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
 

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -174,7 +174,7 @@ describe("Connection", () => {
 
       // Pass an already aborted signal to open()
       abortController.abort();
-      const connectionOpenPromise = connection.open(abortSignal);
+      const connectionOpenPromise = connection.open({ abortSignal });
 
       let abortErrorThrown = false;
       try {
@@ -196,7 +196,7 @@ describe("Connection", () => {
       const abortSignal = abortController.signal;
 
       // Abort the signal after passing it to open()
-      const connectionOpenPromise = connection.open(abortSignal);
+      const connectionOpenPromise = connection.open({ abortSignal });
       abortController.abort();
 
       let abortErrorThrown = false;
@@ -224,7 +224,7 @@ describe("Connection", () => {
 
       // Pass an already aborted signal to close()
       abortController.abort();
-      const connectionClosePromise = connection.close(abortSignal);
+      const connectionClosePromise = connection.close({ abortSignal });
 
       let abortErrorThrown = false;
       try {
@@ -250,7 +250,7 @@ describe("Connection", () => {
       const abortSignal = abortController.signal;
 
       // Abort the signal after passing it to open()
-      const connectionClosePromise = connection.close(abortSignal);
+      const connectionClosePromise = connection.close({ abortSignal });
       abortController.abort();
 
       let abortErrorThrown = false;

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -1,6 +1,8 @@
 import * as rhea from "rhea";
 import { assert } from "chai";
 import { Connection, ConnectionEvents } from "../lib/index";
+import { AbortController } from "@azure/abort-controller";
+import { abortErrorName } from "../lib/util/utils";
 
 describe("Connection", () => {
   let mockService: rhea.Container;
@@ -160,4 +162,347 @@ describe("Connection", () => {
 
     });
   });
+
+  describe("AbortError", () => {
+    it("connection.open() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to open()
+      abortController.abort();
+      const connectionOpenPromise = connection.open(abortSignal);
+
+      let abortErrorThrown = false;
+      try {
+        await connectionOpenPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.")
+      assert.isFalse(connection.isOpen(), "Connection should not be open.");
+    });
+
+    it("connection.open() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to open()
+      const connectionOpenPromise = connection.open(abortSignal);
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await connectionOpenPromise;
+        abortController.abort();
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.")
+      assert.isFalse(connection.isOpen(), "Connection should not be open.");
+    });
+
+    it("connection.close() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+
+      await connection.open();
+      assert.isTrue(connection.isOpen(), "Connection should be open.");
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to close()
+      abortController.abort();
+      const connectionClosePromise = connection.close(abortSignal);
+
+      let abortErrorThrown = false;
+      try {
+        await connectionClosePromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.")
+      assert.isFalse(connection.isOpen(), "Connection should not be open.");
+      assert.isTrue(connection.isRemoteOpen(), "Connection remote endpoint should not have gotten a chance to close.");
+    });
+
+    it("connection.close() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+
+      await connection.open();
+      assert.isTrue(connection.isOpen(), "Connection should be open.");
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to open()
+      const connectionClosePromise = connection.close(abortSignal);
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await connectionClosePromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.")
+      assert.isFalse(connection.isOpen(), "Connection should not be open.");
+      assert.isTrue(connection.isRemoteOpen(), "Connection remote endpoint should not have gotten a chance to close.");
+    });
+
+    it("createSession() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createSession()
+      abortController.abort();
+      const createSessionPromise = connection.createSession(abortSignal);
+
+      let abortErrorThrown = false;
+      try {
+        await createSessionPromise
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createSession() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createSession()
+      const createSessionPromise = connection.createSession(abortSignal);
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createSessionPromise
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createSender() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createSender()
+      abortController.abort();
+      const createSenderPromise = connection.createSender({ abortSignal });
+
+      let abortErrorThrown = false;
+      try {
+        await createSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createSender() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createSender()
+      const createSenderPromise = connection.createSender({ abortSignal });
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createAwaitableSender() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createAwaitableSender()
+      abortController.abort();
+      const createAwaitableSenderPromise = connection.createAwaitableSender({ abortSignal });
+
+      let abortErrorThrown = false;
+      try {
+        await createAwaitableSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createAwaitableSender() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createAwaitableSender()
+      const createAwaitableSenderPromise = connection.createAwaitableSender({ abortSignal });
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createAwaitableSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createReceiver() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createReceiver()
+      abortController.abort();
+      const createReceiverPromise = connection.createReceiver({ abortSignal });
+
+      let abortErrorThrown = false;
+      try {
+        await createReceiverPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createReceiver() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createReceiver()
+      const createReceiverPromise = connection.createReceiver({ abortSignal });
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createReceiverPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createRequestResponseLink() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createReceiver()
+      abortController.abort();
+      const createPromise = connection.createRequestResponseLink({}, {}, undefined, abortSignal);
+
+      let abortErrorThrown = false;
+      try {
+        await createPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createRequestResponseLink() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createReceiver()
+      const createPromise = connection.createRequestResponseLink({}, {}, undefined, abortSignal);
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+  })
 });

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -276,7 +276,7 @@ describe("Connection", () => {
 
       // Pass an already aborted signal to createSession()
       abortController.abort();
-      const createSessionPromise = connection.createSession(abortSignal);
+      const createSessionPromise = connection.createSession({ abortSignal });
 
       let abortErrorThrown = false;
       try {
@@ -299,7 +299,7 @@ describe("Connection", () => {
       const abortSignal = abortController.signal;
 
       // Abort the signal after passing it to createSession()
-      const createSessionPromise = connection.createSession(abortSignal);
+      const createSessionPromise = connection.createSession({ abortSignal });
       abortController.abort();
 
       let abortErrorThrown = false;

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -153,7 +153,7 @@ describe("Sender", () => {
 
       // Pass an already aborted signal to send()
       abortController.abort();
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, abortSignal);
+      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, { abortSignal });
 
       let abortErrorThrown = false;
       try {
@@ -180,7 +180,7 @@ describe("Sender", () => {
 
       // Pass an already aborted signal to send()
       abortController.abort();
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, abortSignal);
+      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, { abortSignal });
 
       let abortErrorThrown = false;
       try {
@@ -205,7 +205,7 @@ describe("Sender", () => {
       const abortSignal = abortController.signal;
 
       // Fire abort signal after passing it to send()
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, abortSignal);
+      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, { abortSignal });
       abortController.abort();
 
 

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -123,6 +123,7 @@ describe("Sender", () => {
     it("send() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const sender = await connection.createAwaitableSender();
@@ -148,6 +149,7 @@ describe("Sender", () => {
     it("send() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const sender = await connection.createAwaitableSender();

--- a/test/session.spec.ts
+++ b/test/session.spec.ts
@@ -1,6 +1,8 @@
 import * as rhea from "rhea";
 import { assert } from "chai";
 import { Connection, SessionEvents, Session } from "../lib/index";
+import { AbortController } from "@azure/abort-controller";
+import { abortErrorName } from "../lib/util/utils";
 
 describe("Session", () => {
   let mockService: rhea.Container;
@@ -177,6 +179,218 @@ describe("Session", () => {
 
       // Open the session.
       session.begin();
+    });
+  });
+
+  describe("AbortError", () => {
+    it("session.close() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+
+      await connection.open();
+      const session = await connection.createSession();
+      assert.isTrue(session.isOpen(), "Session should be open.");
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to close()
+      abortController.abort();
+      const sessionClosePromise = session.close(abortSignal);
+
+      let abortErrorThrown = false;
+      try {
+        await sessionClosePromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.")
+      assert.isFalse(session.isOpen(), "Session should not be open.");
+      assert.isTrue(session["_session"].is_remote_open(), "Session remote endpoint should not have gotten a chance to close.");
+
+      await connection.close();
+    });
+
+    it("session.close() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+
+      await connection.open();
+      const session = await connection.createSession();
+      assert.isTrue(session.isOpen(), "Session should be open.");
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to open()
+      const sessionClosePromise = session.close(abortSignal);
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await sessionClosePromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.")
+      assert.isFalse(session.isOpen(), "Session should not be open.");
+      assert.isTrue(session["_session"].is_remote_open(), "Session remote endpoint should not have gotten a chance to close.");
+
+      await connection.close();
+    });
+
+    it("createSender() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+      const session = await connection.createSession();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createSender()
+      abortController.abort();
+      const createSenderPromise = session.createSender({ abortSignal });
+
+      let abortErrorThrown = false;
+      try {
+        await createSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createSender() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+      const session = await connection.createSession();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createSender()
+      const createSenderPromise = session.createSender({ abortSignal });
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createAwaitableSender() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+      const session = await connection.createSession();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createAwaitableSender()
+      abortController.abort();
+      const createAwaitableSenderPromise = session.createAwaitableSender({ abortSignal });
+
+      let abortErrorThrown = false;
+      try {
+        await createAwaitableSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createAwaitableSender() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+      const session = await connection.createSession();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createAwaitableSender()
+      const createAwaitableSenderPromise = session.createAwaitableSender({ abortSignal });
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createAwaitableSenderPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createReceiver() fails with aborted signal", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+      const session = await connection.createSession();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Pass an already aborted signal to createReceiver()
+      abortController.abort();
+      const createReceiverPromise = session.createReceiver({ abortSignal });
+
+      let abortErrorThrown = false;
+      try {
+        await createReceiverPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
+    });
+
+    it("createReceiver() fails when abort signal is fired", async () => {
+      const connection = new Connection({
+        port: mockServiceListener.address().port,
+      });
+      await connection.open();
+      const session = await connection.createSession();
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      // Abort the signal after passing it to createReceiver()
+      const createReceiverPromise = session.createReceiver({ abortSignal });
+      abortController.abort();
+
+      let abortErrorThrown = false;
+      try {
+        await createReceiverPromise;
+      } catch (error) {
+        abortErrorThrown = error.name === abortErrorName;
+      }
+
+      assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      await connection.close();
     });
   });
 });

--- a/test/session.spec.ts
+++ b/test/session.spec.ts
@@ -197,7 +197,7 @@ describe("Session", () => {
 
       // Pass an already aborted signal to close()
       abortController.abort();
-      const sessionClosePromise = session.close(abortSignal);
+      const sessionClosePromise = session.close({ abortSignal });
 
       let abortErrorThrown = false;
       try {
@@ -226,7 +226,7 @@ describe("Session", () => {
       const abortSignal = abortController.signal;
 
       // Abort the signal after passing it to open()
-      const sessionClosePromise = session.close(abortSignal);
+      const sessionClosePromise = session.close({ abortSignal });
       abortController.abort();
 
       let abortErrorThrown = false;

--- a/test/session.spec.ts
+++ b/test/session.spec.ts
@@ -186,6 +186,7 @@ describe("Session", () => {
     it("session.close() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
 
       await connection.open();
@@ -216,6 +217,7 @@ describe("Session", () => {
     it("session.close() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
 
       await connection.open();
@@ -246,6 +248,7 @@ describe("Session", () => {
     it("createSender() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const session = await connection.createSession();
@@ -271,6 +274,7 @@ describe("Session", () => {
     it("createSender() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const session = await connection.createSession();
@@ -296,6 +300,7 @@ describe("Session", () => {
     it("createAwaitableSender() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const session = await connection.createSession();
@@ -321,6 +326,7 @@ describe("Session", () => {
     it("createAwaitableSender() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const session = await connection.createSession();
@@ -346,6 +352,7 @@ describe("Session", () => {
     it("createReceiver() fails with aborted signal", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const session = await connection.createSession();
@@ -371,6 +378,7 @@ describe("Session", () => {
     it("createReceiver() fails when abort signal is fired", async () => {
       const connection = new Connection({
         port: mockServiceListener.address().port,
+        reconnect: false,
       });
       await connection.open();
       const session = await connection.createSession();


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- This PR adds support for cancelling all the async operations via the use of the standard AbortSignalLike interface
- This mainly involves clearing the associated timer at its base, followed by any other clean up that is needed.

Few design discussions:
- `AbortSignalLike` interface is redefined in this PR instead of relying on an Azure scoped package like `@azure/abort-controller` which is used in the tests
- I refrained from redefining the `AbortError` class due to potential conflicts with upstream usage. Instead, using same old `Error` class with custom name. This is definitely open for debate as to how we should approach this.


## Reference to any github issues
-  #48
