### PR TITLE
Pin TS version to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -920,9 +920,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rimraf": "^2.6.3",
     "ts-node": "^8.2.0",
     "tslint": "^5.17.0",
-    "typescript": "^3.5.1"
+    "typescript": "3.5.1"
   },
   "scripts": {
     "tslint": "tslint -p . -c tslint.json --exclude tests/**/*.ts",

--- a/test/receiver.spec.ts
+++ b/test/receiver.spec.ts
@@ -98,7 +98,7 @@ describe("Receiver", () => {
       mockService.on(
         rhea.SenderEvents.senderClose,
         (context: rhea.EventContext) => {
-          context.sender?.close({
+          context.sender && context.sender.close({
             condition: errorCondition,
             description: errorDescription,
           });

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -75,10 +75,11 @@ describe("Sender", () => {
     mockService.on(
       rhea.ReceiverEvents.receiverOpen,
       (context: rhea.EventContext) => {
-        context.receiver?.close({
-          condition: errorCondition,
-          description: errorDescription,
-        });
+        context.receiver &&
+          context.receiver.close({
+            condition: errorCondition,
+            description: errorDescription,
+          });
       }
     );
 
@@ -119,10 +120,11 @@ describe("Sender", () => {
       mockService.on(
         rhea.ReceiverEvents.receiverClose,
         (context: rhea.EventContext) => {
-          context.receiver?.close({
-            condition: errorCondition,
-            description: errorDescription,
-          });
+          context.receiver &&
+            context.receiver.close({
+              condition: errorCondition,
+              description: errorDescription,
+            });
         }
       );
 

--- a/test/session.spec.ts
+++ b/test/session.spec.ts
@@ -122,10 +122,11 @@ describe("Session", () => {
       mockService.on(
         rhea.SessionEvents.sessionOpen,
         (context: rhea.EventContext) => {
-          context.session?.close({
-            condition: errorCondition,
-            description: errorDescription,
-          });
+          context.session &&
+            context.session.close({
+              condition: errorCondition,
+              description: errorDescription,
+            });
         }
       );
 
@@ -136,10 +137,13 @@ describe("Session", () => {
 
       session.on(SessionEvents.sessionError, async (event) => {
         assert.exists(event, "Expected an AMQP event.");
-        const error = event.session?.error as rhea.ConnectionError;
-        assert.exists(error, "Expected an AMQP error.");
-        assert.strictEqual(error.condition, errorCondition);
-        assert.strictEqual(error.description, errorDescription);
+        assert.exists(event.session, "Expected session to be defined on AMQP event.");
+        if (event.session) {
+          const error = event.session.error as rhea.ConnectionError;
+          assert.exists(error, "Expected an AMQP error.");
+          assert.strictEqual(error.condition, errorCondition);
+          assert.strictEqual(error.description, errorDescription);
+        }
         await session.close();
         done();
       });
@@ -153,10 +157,11 @@ describe("Session", () => {
       mockService.on(
         rhea.SessionEvents.sessionClose,
         (context: rhea.EventContext) => {
-          context.session?.close({
-            condition: errorCondition,
-            description: errorDescription,
-          });
+          context.session &&
+            context.session.close({
+              condition: errorCondition,
+              description: errorDescription,
+            });
         }
       );
 


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- Pin TS version to 3.5.1 to keep the dist artifacts look similar to the older ones.
- Artifacts with `TS@3.9.x` failed with bundling when tested with the package `@azure/core-amqp` that depends on rhea-promise https://dev.azure.com/azure-sdk/internal/_build/results?buildId=720614&view=logs&j=d25e7329-9524-595e-1030-bc1e9a340f40&t=0db4e429-9b55-5e39-a2c0-293aad8014c9 
