### PR TITLE
Bug Fix: AwaitableSender.send() resolves to undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export DEBUG=rhea*,-rhea:raw,-rhea:message,-rhea-promise:eventhandler,-rhea-prom
 
 ## Notable differences between rhea and rhea-promise
 
-### Error propogation to the parent entity
+### Error propagation to the parent entity
 - In `AMQP`, for two peers to communicate successfully, different entities (Container, Connection, Session, Link) need to be created. There is a relationship between those entities.
   - 1 Container can have 1..* Connections.
   - 1 Connection can have 1..* Sessions. 
@@ -55,15 +55,15 @@ export DEBUG=rhea*,-rhea:raw,-rhea:message,-rhea-promise:eventhandler,-rhea-prom
 - Each entity (connection, session, link) maintains its own state to let other entities know about what it is doing. Thus,
   - if the connection goes down then, everything on the connection - sessions, links are down.
   - if a session goes down then, all the the links on that session are down.
-- When an entity goes down rhea emits \*_error and \*_close events, where * can be "sender", "receiver", "session", "connection". If event listeners for the aforementioned events are not added at the appropriate level, then `rhea` propogates those events to its parent entity. 
+- When an entity goes down rhea emits \*_error and \*_close events, where * can be "sender", "receiver", "session", "connection". If event listeners for the aforementioned events are not added at the appropriate level, then `rhea` propagates those events to its parent entity. 
 If they are not handled at the `Container` level (uber parent), then they are transformed into an `error` event. This would cause your 
 application to crash if there is no listener added for the `error` event.
 - In `rhea-promise`, the library creates, equivalent objects `Connection, Session, Sender, Receiver` and wraps objects from `rhea` within them.
 It adds event listeners to all the possible events that can occur at any level and re-emits those events with the same arguments as one would 
 expect from rhea. This makes it easy for consumers of `rhea-promise` to use the **EventEmitter** pattern. Users can efficiently use different 
 event emitter methods like `.once()`, `.on()`, `.prependListeners()`, etc. Since `rhea-promise` add those event listeners on `rhea` objects, 
-the errors will never be propogated to the parent entity. This can be good as well as bad depending on what you do.
-   - **Good** - `*_error` events and `*_close` events emitted on an entity will not be propogated to it's parent. Thus ensuring that errors are handled at the right level.
+the errors will never be propagated to the parent entity. This can be good as well as bad depending on what you do.
+   - **Good** - `*_error` events and `*_close` events emitted on an entity will not be propagated to it's parent. Thus ensuring that errors are handled at the right level.
    - **Bad** - If you do not add listeners for `*_error` and `*_close` events at the right level, then you will never know why an entity shutdown.
 
 We believe our design enforces good practices to be followed while using the event emitter pattern.

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -238,8 +238,8 @@ export class AwaitableSender extends BaseSender {
 
         const delivery = (this._link as RheaSender).send(msg, tag, format);
         this.deliveryDispositionMap.set(delivery.id, {
-          resolve: () => {
-            resolve();
+          resolve: (delivery: any) => {
+            resolve(delivery);
             removeAbortListener();
           },
           reject: (reason?: any) => {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -181,7 +181,7 @@ export declare interface Connection {
 }
 
 /**
- * Descibes the AQMP Connection.
+ * Describes the AMQP Connection.
  * @class Connection
  */
 export class Connection extends Entity {
@@ -632,7 +632,7 @@ export class Connection extends Entity {
    * `deliveryDispositionMap`.
    * - If the user is handling the reconnection of sender link or the underlying connection in it's
    * app, then the `onError` and `onSessionError` handlers must be provided by the user and (s)he
-   * shall be responsible of clearing the `deliveryDispotionMap` of inflight `send()` operation.
+   * shall be responsible of clearing the `deliveryDispositionMap` of inflight `send()` operation.
    *
    * @return Promise<AwaitableSender>.
    */
@@ -715,7 +715,7 @@ export class Connection extends Entity {
       });
     }
 
-    // Add event handlers for *_error and *_close events that can be propogated to the connection
+    // Add event handlers for *_error and *_close events that can be propagated to the connection
     // object, if they are not handled at their level. * denotes - Sender, Receiver, Session
 
     // Sender

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -566,7 +566,7 @@ export class Session extends Entity {
         });
     }
 
-    // Add event handlers for *_error and *_close events that can be propogated to the session
+    // Add event handlers for *_error and *_close events that can be propagated to the session
     // object, if they are not handled at their level. * denotes - Sender and Receiver.
 
     // Sender

--- a/test/receiver.spec.ts
+++ b/test/receiver.spec.ts
@@ -98,7 +98,7 @@ describe("Receiver", () => {
       mockService.on(
         rhea.SenderEvents.senderClose,
         (context: rhea.EventContext) => {
-          context.sender?.close({
+          context.sender && context.sender.close({
             condition: errorCondition,
             description: errorDescription,
           });

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -42,6 +42,18 @@ describe("Sender", () => {
     assert.isFalse(sender.isOpen(), "Sender should not be open.");
   });
 
+  it("Delivery returned from `AwaitableSender.send()` is not undefined", async () => {
+    const sender = await connection.createAwaitableSender({
+      sendTimeoutInSeconds: 1,
+    });
+    const response = await sender.send({ body: "message" });
+    assert.exists(
+      response,
+      "Response from the AwaitableSender.send() is undefined"
+    );
+    await sender.close();
+  });
+
   it(".remove() removes event listeners", async () => {
     const sender = await connection.createSender();
     sender.on(rhea.SenderEvents.senderOpen, () => {

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -51,6 +51,10 @@ describe("Sender", () => {
       response,
       "Response from the AwaitableSender.send() is undefined"
     );
+    assert.exists(
+      response.id,
+      "Delivery returned from the AwaitableSender.send() is undefined"
+    );
     await sender.close();
   });
 
@@ -78,7 +82,6 @@ describe("Sender", () => {
     await sender.close();
 
     assert.strictEqual(sender.listenerCount(rhea.SenderEvents.senderOpen), 0);
-
   });
 
   it("createSender() bubbles up error", async () => {
@@ -112,18 +115,23 @@ describe("Sender", () => {
     });
     await connection.open();
     const sender = await connection.createAwaitableSender();
-    sender.sendable = () => { return false }
+    sender.sendable = () => {
+      return false;
+    };
 
     let insufficientCreditErrorThrown = false;
     try {
       await sender.send({ body: "hello" });
     } catch (error) {
-      insufficientCreditErrorThrown = error instanceof InsufficientCreditError
+      insufficientCreditErrorThrown = error instanceof InsufficientCreditError;
     }
 
-    assert.isTrue(insufficientCreditErrorThrown, "AbortError should have been thrown.");
+    assert.isTrue(
+      insufficientCreditErrorThrown,
+      "AbortError should have been thrown."
+    );
     await connection.close();
-  })
+  });
 
   describe("supports events", () => {
     it("senderError on sender.close() is bubbled up", async () => {
@@ -144,7 +152,7 @@ describe("Sender", () => {
 
       try {
         await sender.close();
-        throw new Error("boo")
+        throw new Error("boo");
       } catch (error) {
         assert.exists(error, "Expected an AMQP error.");
         assert.strictEqual(error.condition, errorCondition);
@@ -167,7 +175,9 @@ describe("Sender", () => {
 
       // Pass an already aborted signal to send()
       abortController.abort();
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, { abortSignal });
+      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, {
+        abortSignal,
+      });
 
       let abortErrorThrown = false;
       try {
@@ -187,14 +197,18 @@ describe("Sender", () => {
       });
       await connection.open();
       const sender = await connection.createAwaitableSender();
-      sender.sendable = () => { return false }
+      sender.sendable = () => {
+        return false;
+      };
 
       const abortController = new AbortController();
       const abortSignal = abortController.signal;
 
       // Pass an already aborted signal to send()
       abortController.abort();
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, { abortSignal });
+      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, {
+        abortSignal,
+      });
 
       let abortErrorThrown = false;
       try {
@@ -219,9 +233,10 @@ describe("Sender", () => {
       const abortSignal = abortController.signal;
 
       // Fire abort signal after passing it to send()
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, { abortSignal });
+      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, {
+        abortSignal,
+      });
       abortController.abort();
-
 
       let abortErrorThrown = false;
       try {
@@ -233,5 +248,5 @@ describe("Sender", () => {
       assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
       await connection.close();
     });
-  })
+  });
 });

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -87,10 +87,11 @@ describe("Sender", () => {
     mockService.on(
       rhea.ReceiverEvents.receiverOpen,
       (context: rhea.EventContext) => {
-        context.receiver?.close({
-          condition: errorCondition,
-          description: errorDescription,
-        });
+        context.receiver &&
+          context.receiver.close({
+            condition: errorCondition,
+            description: errorDescription,
+          });
       }
     );
 
@@ -131,10 +132,11 @@ describe("Sender", () => {
       mockService.on(
         rhea.ReceiverEvents.receiverClose,
         (context: rhea.EventContext) => {
-          context.receiver?.close({
-            condition: errorCondition,
-            description: errorDescription,
-          });
+          context.receiver &&
+            context.receiver.close({
+              condition: errorCondition,
+              description: errorDescription,
+            });
         }
       );
 

--- a/test/session.spec.ts
+++ b/test/session.spec.ts
@@ -122,10 +122,11 @@ describe("Session", () => {
       mockService.on(
         rhea.SessionEvents.sessionOpen,
         (context: rhea.EventContext) => {
-          context.session?.close({
-            condition: errorCondition,
-            description: errorDescription,
-          });
+          context.session &&
+            context.session.close({
+              condition: errorCondition,
+              description: errorDescription,
+            });
         }
       );
 
@@ -136,10 +137,13 @@ describe("Session", () => {
 
       session.on(SessionEvents.sessionError, async (event) => {
         assert.exists(event, "Expected an AMQP event.");
-        const error = event.session?.error as rhea.ConnectionError;
-        assert.exists(error, "Expected an AMQP error.");
-        assert.strictEqual(error.condition, errorCondition);
-        assert.strictEqual(error.description, errorDescription);
+        assert.exists(event.session, "Expected session to be defined on AMQP event.");
+        if (event.session) {
+          const error = event.session.error as rhea.ConnectionError;
+          assert.exists(error, "Expected an AMQP error.");
+          assert.strictEqual(error.condition, errorCondition);
+          assert.strictEqual(error.description, errorDescription);
+        }
         await session.close();
         done();
       });
@@ -153,10 +157,11 @@ describe("Session", () => {
       mockService.on(
         rhea.SessionEvents.sessionClose,
         (context: rhea.EventContext) => {
-          context.session?.close({
-            condition: errorCondition,
-            description: errorDescription,
-          });
+          context.session &&
+            context.session.close({
+              condition: errorCondition,
+              description: errorDescription,
+            });
         }
       );
 


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- `AwaitableSender.send()` is expected to resolve with the delivery. However, nothing was being passed to `resolve()`, leading to resolving `undefined`.
- To facilitate a smooth 1.1.0 release, as suggested at https://github.com/amqp/rhea-promise/pull/76, downgrading the TS features in the tests so the build doesn't fail.

## Reference to any github issues
- Found it while testing the dependant service-bus package with 1.1.0 rhea-promise. https://dev.azure.com/azure-sdk/internal/_build/results?buildId=720614&view=logs&j=d25e7329-9524-595e-1030-bc1e9a340f40&t=0db4e429-9b55-5e39-a2c0-293aad8014c9
