### PR TITLE
Fix `MaxListenersExceededWarning` - "disconnected listeners" with `disconnectEventAudienceMap`

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -248,6 +248,11 @@ export class Connection extends Entity {
     this.options = this._connection.options;
     this.options.operationTimeoutInSeconds = options.operationTimeoutInSeconds;
 
+    // Disconnect event for the disconnectEventAudienceMap
+    this._connection.on(ConnectionEvents.disconnected, (context) => {
+      onDisconnectOccurrence(context, this._disconnectEventAudienceMap);
+    });
+
     this._initializeEventListeners();
   }
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -180,6 +180,13 @@ export declare interface Connection {
   on(event: ConnectionEvents, listener: OnAmqpEvent): this;
 }
 
+function onDisconnectOccurrence(
+  context: RheaEventContext,
+  disconnectEventAudienceMap: Map<string, (context: RheaEventContext) => void>
+): void {
+  disconnectEventAudienceMap.forEach((callback) => callback(context));
+}
+
 /**
  * Describes the AMQP Connection.
  * @class Connection

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -166,7 +166,7 @@ export interface ReqResLink {
    */
   receiver: Receiver;
   /**
-   * @property {Session} session - The underlying session on whicn the sender and receiver links
+   * @property {Session} session - The underlying session on which the sender and receiver links
    * exist.
    */
   session: Session;

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -248,7 +248,7 @@ export class Connection extends Entity {
     this.options = this._connection.options;
     this.options.operationTimeoutInSeconds = options.operationTimeoutInSeconds;
 
-    // Disconnect event for the disconnectEventAudienceMap
+    // Disconnected event listener for the disconnectEventAudienceMap
     this._connection.on(ConnectionEvents.disconnected, (context) => {
       onDisconnectOccurrence(context, this._disconnectEventAudienceMap);
     });

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -198,6 +198,15 @@ export class Connection extends Entity {
    */
   options: ConnectionOptions;
   /**
+   * Maintains a map of the audience(sessions/senders/receivers) interested in "disconnected" event.
+   * This helps us with not needing to create too many listeners on the "disconnected" event,
+   * which is particularly useful when dealing with 1000s of sessions at the same time.
+   */
+  _disconnectEventAudienceMap: Map<string, (context: RheaEventContext) => void> = new Map<
+    string,
+    (context: RheaEventContext) => void
+  >();
+  /**
    * @property {Container} container The underlying Container instance on which the connection
    * exists.
    */

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -167,6 +167,8 @@ export class Session extends Entity {
         let waitTimer: any;
 
         const removeListeners = () => {
+          // Remove the listener <=> delete from map
+          this._connection._disconnectEventAudienceMap.delete(this.id);
           clearTimeout(waitTimer);
           this.actionInitiated--;
           this._session.removeListener(SessionEvents.sessionError, onError);

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -226,12 +226,6 @@ export class Session extends Entity {
               context.connection && context.connection.error
                 ? context.connection.error
                 : context.error;
-            console.log(
-              "[%s] Connection got disconnected while closing amqp session '%s': %O.",
-              this.connection.id,
-              this.id,
-              error
-            );
             log.error(
               "[%s] Connection got disconnected while closing amqp session '%s': %O.",
               this.connection.id,

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -218,6 +218,28 @@ export class Session extends Entity {
         this._session.once(SessionEvents.sessionClose, onClose);
         this._session.once(SessionEvents.sessionError, onError);
         this._session.connection.once(ConnectionEvents.disconnected, onDisconnected);
+        // Add listener <=> set in the map
+        this._connection._disconnectEventAudienceMap.set(
+          this.id, (context: RheaEventContext) => {
+            removeListeners();
+            const error =
+              context.connection && context.connection.error
+                ? context.connection.error
+                : context.error;
+            console.log(
+              "[%s] Connection got disconnected while closing amqp session '%s': %O.",
+              this.connection.id,
+              this.id,
+              error
+            );
+            log.error(
+              "[%s] Connection got disconnected while closing amqp session '%s': %O.",
+              this.connection.id,
+              this.id,
+              error
+            );
+          }
+        );
         log.session("[%s] Calling session.close() for amqp session '%s'.", this.connection.id, this.id);
         waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
         this._session.close();

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -404,7 +404,7 @@ export class Session extends Entity {
    * `deliveryDispositionMap`.
    * - If the user is handling the reconnection of sender link or the underlying connection in it's
    * app, then the `onError` and `onSessionError` handlers must be provided by the user and (s)he
-   * shall be responsible of clearing the `deliveryDispotionMap` of inflight `send()` operation.
+   * shall be responsible of clearing the `deliveryDispositionMap` of inflight `send()` operation.
    *
    * @return Promise<AwaitableSender>
    * - **Resolves** the promise with the Sender object when rhea emits the "sender_open" event.


### PR DESCRIPTION
## Description
### MaxListenersExceededWarning - "disconnected listeners" - Cause 

- Observed the following warning while stress testing service-bus JS SDK - https://github.com/Azure/azure-sdk-for-js/issues/12161
   - `(node:6245) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 disconnected listeners added to [Connection]. Use emitter.setMaxListeners() to increase limit`  
- Session.close() - adds the disconnected listener, and the listener would be removed upon "session_close" event. 
- When there are many sessions(service-bus sessions) with "SessionLockLost" error triggered by the renewlocks, Session.close() is called for each of the sessions in parallel, which led to many disconnected listeners on the same connection. The listener count went to as high as 700 when dealt with 1000 concurrent sessions. This led to the MaxListenersExceededWarning.
- For each of the Session.close(), upon "session_close" event, the added listeners were removed one by one. So, it is not fatal, it gets recovered. But momentarily, there are too many listeners to the same "disconnected" event.

### Fix
- Idea is to not add many listers for the same event - inspiration from what we did for core-amqp at https://github.com/Azure/azure-sdk-for-js/pull/11749
- Instead of adding many listeners on the same connection for each of the session ids, the plan is to add only a single listener for the disconnected event on the connection.
- The connection maintains an active map of session ids with the provided callbacks. Instead of adding a new listener for the disconnected event on the connection, whoever(session) wants to listen to the "disconnected" event would set their id with a callback on that active map maintained at the connection level.
- All the callbacks are called in a loop if the disconnected event is _listened_ by that single common listener.

## Reference to any GitHub issues
- https://github.com/Azure/azure-sdk-for-js/issues/12161