### PR TITLE
Add "incoming" to allow querying size and capacity of the deliveries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### 1.1.1 - Unreleased
+- Exposes the `incoming` getter on the `Session` that lets accessing size and capacity of the incoming deliveries [#79](https://github.com/amqp/rhea-promise/pull/79).
+
 ### 1.1.0 - 2021-02-08
 - All async methods now take a signal that can be used to cancel the operation. Fixes [#48](https://github.com/amqp/rhea-promise/issues/48)
 - Added a `timeoutInSeconds` parameter to the `send` method on the `AwaitableSender` that overrides the timeout value for the send operation set when creating the sender.

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -60,6 +60,10 @@ export class Session extends Entity {
     return this._connection;
   }
 
+  get incoming(): { deliveries: { size: number; capacity: number } } {
+    return (this._session as any).incoming;
+  }
+
   get outgoing(): any {
     return (this._session as any).outgoing;
   }


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- This PR attempts to allow accessing the properties on incoming deliveries of a session, to allow the applications to manage the addition of credits based on the free slots in the incoming buffer of deliveries https://github.com/Azure/azure-sdk-for-js/pull/14060 
- More info https://github.com/Azure/azure-sdk-for-js/pull/14060#discussion_r590749196
- Testing this branch with service-bus through https://github.com/HarshaNalluru/rhea-promise/tree/harshan/sb/issue-14060-test
  - https://github.com/Azure/azure-sdk-for-js/pull/14060/commits/478a7ae7c2eb1b0060dda76ca3239fb494ee510b and https://github.com/Azure/azure-sdk-for-js/pull/14060/commits/9f2fd9bf5b8b593fa567c60921dd3e96f6f94dfd imports the updates rhea-promise and makes sure the tests are fine.
    > ![image](https://user-images.githubusercontent.com/10452642/110871288-f6a06c00-8282-11eb-9d3e-8d7ba003dfd6.png)

## Reference to any github issues
- https://github.com/Azure/azure-sdk-for-js/pull/14060
- https://github.com/Azure/azure-sdk-for-js/pull/14060#discussion_r590749196
