### PR TITLE
Use standard error message for AbortError

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### 1.1.1 - Unreleased
 - Exposes the `incoming` getter on the `Session` that lets accessing size and capacity of the incoming deliveries [#79](https://github.com/amqp/rhea-promise/pull/79).
+- Updates the error message for the `AbortError` to be a standard message `The operation was aborted.`.
 
 ### 1.1.0 - 2021-02-08
 - All async methods now take a signal that can be used to cancel the operation. Fixes [#48](https://github.com/amqp/rhea-promise/issues/48)

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -199,7 +199,7 @@ export class AwaitableSender extends BaseSender {
       const timeoutInSeconds = options && options.timeoutInSeconds;
 
       if (abortSignal && abortSignal.aborted) {
-        const err = createAbortError("Send request has been cancelled.");
+        const err = createAbortError();
         log.error("[%s] %s", this.connection.id, err.message);
         return reject(err);
       }
@@ -226,7 +226,7 @@ export class AwaitableSender extends BaseSender {
               " map of sender '%s' on amqp session '%s' and cleared the timer: %s.",
               this.connection.id, delivery.id, this.name, this.session.id, deleteResult
             );
-            const err = createAbortError("Send request has been cancelled.");
+            const err = createAbortError();
             log.error("[%s] %s", this.connection.id, err.message);
             promise.reject(err);
           }

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -336,7 +336,7 @@ export class Connection extends Entity {
         onAbort = () => {
           removeListeners();
           this._connection.close();
-          const err = createAbortError("Connection open request has been cancelled.");
+          const err = createAbortError();
           log.error("[%s] [%s]", this.id, err.message);
           return reject(err);
         };
@@ -426,7 +426,7 @@ export class Connection extends Entity {
 
         onAbort = () => {
           removeListeners();
-          const err = createAbortError("Connection close request has been cancelled.");
+          const err = createAbortError();
           log.error("[%s] [%s]", this.id, err.message);
           return reject(err);
         };
@@ -578,7 +578,7 @@ export class Connection extends Entity {
       onAbort = () => {
         removeListeners();
         rheaSession.close();
-        const err = createAbortError("Create session request has been cancelled.");
+        const err = createAbortError();
         log.error("[%s] [%s]", this.id, err.message);
         return reject(err);
       };

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -204,7 +204,7 @@ export class Session extends Entity {
 
         onAbort = () => {
           removeListeners();
-          const err = createAbortError("Session close request has been cancelled.");
+          const err = createAbortError();
           log.error("[%s] [%s]", this.connection.id, err.message);
           return reject(err);
         };
@@ -359,7 +359,7 @@ export class Session extends Entity {
       onAbort = () => {
         removeListeners();
         rheaReceiver.close();
-        const err = createAbortError("Create receiver request has been cancelled.");
+        const err = createAbortError();
         log.error("[%s] [%s]", this.connection.id, err.message);
         return reject(err);
       };
@@ -519,7 +519,7 @@ export class Session extends Entity {
       onAbort = () => {
         removeListeners();
         rheaSender.close();
-        const err = createAbortError("Create sender request has been cancelled.");
+        const err = createAbortError();
         log.error("[%s] [%s]", this.connection.id, err.message);
         return reject(err);
       };

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -226,10 +226,9 @@ export const abortErrorName = "AbortError";
 /**
  * Helper method to return an Error to be used when an operation is cancelled
  * using an AbortSignalLike
- * @param errorMessage
  */
-export function createAbortError(errorMessage: string): Error {
-  const error = new Error(errorMessage);
+export function createAbortError(): Error {
+  const error = new Error("The operation was aborted.");
   error.name = abortErrorName;
   return error;
 }


### PR DESCRIPTION
The `AbortError` is thrown from multiple places with different error messages. To provide a standard, uniform experience, this PR updates the error message to be consistent.