### PR TITLE
[bugfix] improves behavior of session/receiver/sender creation methods during cancellation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### 1.2.1 - (Undeclared)
+### 1.2.1 - (2021-04-15)
 
 - `createSession`, `createReceiver`, and `createSender` methods now only close underlying rhea analogue when cancelled if the resource has already been opened.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 1.2.1 - (Undeclared)
+
+- `createSession`, `createReceiver`, and `createSender` methods now only close underlying rhea analogue when cancelled if the resource has already been opened.
+
 ### 1.2.0 - 2021-03-25
 - Exposes the `incoming` getter on the `Session` that lets accessing size and capacity of the incoming deliveries [#79](https://github.com/amqp/rhea-promise/pull/79).
 - Updates the error message for the `AbortError` to be a standard message `The operation was aborted.`.

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -533,6 +533,20 @@ export class Connection extends Entity {
    */
   createSession(options?: SessionCreateOptions): Promise<Session> {
     return new Promise((resolve, reject) => {
+      const abortSignal = options && options.abortSignal;
+      let rejectOnAbort: Func<void, void>;
+      if (abortSignal) {
+        rejectOnAbort = () => {
+          const err = createAbortError();
+          log.error("[%s] [%s]", this.id, err.message);
+          return reject(err);
+        };
+        if (abortSignal.aborted) {
+          // Exit early before we do any work.
+          return rejectOnAbort();
+        }
+      }
+
       const rheaSession = this._connection.create_session();
       const session = new Session(this, rheaSession);
       session.actionInitiated++;
@@ -540,7 +554,6 @@ export class Connection extends Entity {
       let onClose: Func<RheaEventContext, void>;
       let onDisconnected: Func<RheaEventContext, void>;
       let onAbort: Func<void, void>;
-      const abortSignal = options && options.abortSignal;
       let waitTimer: any;
 
       const removeListeners = () => {
@@ -578,11 +591,21 @@ export class Connection extends Entity {
       onAbort = () => {
         removeListeners();
         if (rheaSession.is_open()) {
+          // This scenario *shouldn't* be possible because if `is_open()` returns true,
+          // our `onOpen` handler should have executed and removed this abort listener.
+          // This is a 'just in case' check in case the operation was cancelled sometime
+          // between when the session's state was updated and when the sessionOpen
+          // event was emitted.
           rheaSession.close();
+        } else if (!rheaSession.is_closed()) {
+          // If the rheaSession isn't closed, then it's possible the peer will still
+          // attempt to begin the session.
+          // We can detect that if it occurs and close our session.
+          rheaSession.once(SessionEvents.sessionOpen, () => {
+            rheaSession.close();
+          });
         }
-        const err = createAbortError();
-        log.error("[%s] [%s]", this.id, err.message);
-        return reject(err);
+        return rejectOnAbort();
       };
 
       const actionAfterTimeout = () => {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -577,7 +577,9 @@ export class Connection extends Entity {
 
       onAbort = () => {
         removeListeners();
-        rheaSession.close();
+        if (rheaSession.is_open()) {
+          rheaSession.close();
+        }
         const err = createAbortError();
         log.error("[%s] [%s]", this.id, err.message);
         return reject(err);

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -275,6 +275,20 @@ export class Session extends Entity {
         }
       }
 
+      const abortSignal = options && options.abortSignal;
+      let rejectOnAbort: Func<void, void>;
+      if (abortSignal) {
+        rejectOnAbort = () => {
+          const err = createAbortError();
+          log.error("[%s] [%s]", this.connection.id, err.message);
+          return reject(err);
+        };
+        if (abortSignal.aborted) {
+          // Exit early before we do any work.
+          return rejectOnAbort();
+        }
+      }
+
       // Register session handlers for session_error and session_close if provided.
       // listeners provided by the user in the options object should be added
       // to our (rhea-promise) object.
@@ -296,7 +310,6 @@ export class Session extends Entity {
       let onClose: Func<RheaEventContext, void>;
       let onDisconnected: Func<RheaEventContext, void>;
       let onAbort: Func<void, void>;
-      const abortSignal = options && options.abortSignal;
       let waitTimer: any;
 
       if (options && options.onMessage) {
@@ -359,11 +372,21 @@ export class Session extends Entity {
       onAbort = () => {
         removeListeners();
         if (rheaReceiver.is_open()) {
+          // This scenario *shouldn't* be possible because if `is_open()` returns true,
+          // our `onOpen` handler should have executed and removed this abort listener.
+          // This is a 'just in case' check in case the operation was cancelled sometime
+          // between when the receiver's state was updated and when the receiverOpen
+          // event was emitted.
           rheaReceiver.close();
+        } else if (!rheaReceiver.is_closed()) {
+          // If the rheaReceiver isn't closed, then it's possible the peer will still
+          // attempt to attach the link and open our receiver.
+          // We can detect that if it occurs and close our receiver.
+          rheaReceiver.once(ReceiverEvents.receiverOpen, () => {
+            rheaReceiver.close();
+          });
         }
-        const err = createAbortError();
-        log.error("[%s] [%s]", this.connection.id, err.message);
-        return reject(err);
+        return rejectOnAbort();
       };
 
       const actionAfterTimeout = () => {
@@ -381,11 +404,7 @@ export class Session extends Entity {
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
 
       if (abortSignal) {
-        if (abortSignal.aborted) {
-          onAbort();
-        } else {
-          abortSignal.addEventListener("abort", onAbort);
-        }
+        abortSignal.addEventListener("abort", onAbort);
       }
     });
   }
@@ -431,6 +450,20 @@ export class Session extends Entity {
     type: SenderType,
     options?: (SenderOptions | AwaitableSenderOptions) & { abortSignal?: AbortSignalLike; }): Promise<Sender | AwaitableSender> {
     return new Promise((resolve, reject) => {
+      const abortSignal = options && options.abortSignal;
+      let rejectOnAbort: Func<void, void>;
+      if (abortSignal) {
+        rejectOnAbort = () => {
+          const err = createAbortError();
+          log.error("[%s] [%s]", this.connection.id, err.message);
+          return reject(err);
+        };
+        if (abortSignal.aborted) {
+          // Exit early before we do any work.
+          return rejectOnAbort();
+        }
+      }
+
       // Register session handlers for session_error and session_close if provided.
       if (options && options.onSessionError) {
         this.on(SessionEvents.sessionError, options.onSessionError);
@@ -456,7 +489,6 @@ export class Session extends Entity {
       let onClose: Func<RheaEventContext, void>;
       let onDisconnected: Func<RheaEventContext, void>;
       let onAbort: Func<void, void>;
-      const abortSignal = options && options.abortSignal;
       let waitTimer: any;
 
       // listeners provided by the user in the options object should be added
@@ -521,11 +553,21 @@ export class Session extends Entity {
       onAbort = () => {
         removeListeners();
         if (rheaSender.is_open()) {
+          // This scenario *shouldn't* be possible because if `is_open()` returns true,
+          // our `onOpen` handler should have executed and removed this abort listener.
+          // This is a 'just in case' check in case the operation was cancelled sometime
+          // between when the sender's state was updated and when the senderOpen
+          // event was emitted.
           rheaSender.close();
+        } else if (!rheaSender.is_closed()) {
+          // If the rheaSender isn't closed, then it's possible the peer will still
+          // attempt to attach the link and open our sender.
+          // We can detect that if it occurs and close our sender.
+          rheaSender.once(SenderEvents.senderOpen, () => {
+            rheaSender.close();
+          });
         }
-        const err = createAbortError();
-        log.error("[%s] [%s]", this.connection.id, err.message);
-        return reject(err);
+        return rejectOnAbort();
       };
 
       const actionAfterTimeout = () => {
@@ -543,11 +585,7 @@ export class Session extends Entity {
       waitTimer = setTimeout(actionAfterTimeout, this.connection.options!.operationTimeoutInSeconds! * 1000);
 
       if (abortSignal) {
-        if (abortSignal.aborted) {
-          onAbort();
-        } else {
-          abortSignal.addEventListener("abort", onAbort);
-        }
+        abortSignal.addEventListener("abort", onAbort);
       }
     });
   }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -358,7 +358,9 @@ export class Session extends Entity {
 
       onAbort = () => {
         removeListeners();
-        rheaReceiver.close();
+        if (rheaReceiver.is_open()) {
+          rheaReceiver.close();
+        }
         const err = createAbortError();
         log.error("[%s] [%s]", this.connection.id, err.message);
         return reject(err);
@@ -518,7 +520,9 @@ export class Session extends Entity {
 
       onAbort = () => {
         removeListeners();
-        rheaSender.close();
+        if (rheaSender.is_open()) {
+          rheaSender.close();
+        }
         const err = createAbortError();
         log.error("[%s] [%s]", this.connection.id, err.message);
         return reject(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -451,6 +451,8 @@ describe("Connection", () => {
       }
 
       assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      const sessionMap = (connection["_connection"] as any)["local_channel_map"];
+      assert.deepEqual(sessionMap, {});
       await connection.close();
     });
 
@@ -476,6 +478,17 @@ describe("Connection", () => {
       }
 
       assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
+      const sessionMap = (connection["_connection"] as any)["local_channel_map"];
+      // There should be at most 1 session.
+      const [sessionName] = Object.keys(sessionMap);
+      const session = sessionName && sessionMap[sessionName];
+      if (!session.is_closed()) {
+        await new Promise(resolve => {
+          session.once(rhea.SessionEvents.sessionClose, resolve);
+        });
+      }
+      assert.isTrue(session.is_closed(), "Session should be closed.");
+      assert.deepEqual(sessionMap, {});
       await connection.close();
     });
 


### PR DESCRIPTION
## Description

When createSession, createReceiver, or createSender are cancelled via an abortSignal, the underlying rhea analogue is closed, regardless of if it has actually been opened.

In the `@azure/event-hubs` library, I ran into an edge case caused by this behavior. In `@azure/event-hubs`, I had a scenario where I'd create multiple receivers expecting an error from the service, and then triggered the abortSignal as soon as the 1st receiver was created. Any receivers that weren't opened prior to the abortSignal being triggered would cause the service to respond with an error stating they could not find the receiver's session handle in the connection.

This error from the service makes sense because from the service's point of view, it never saw a session for the receiver created.

This PR adds a check before closing the underlying rhea resource that ensures it is actually open 1st.

## Edit:

I updated the logic around when to close the rhea session/receiver/sender when cancelling their creation.

Through some more testing I found that each resource's `open` event could still be emitted after aborting even if `resource.is_open()` returned false. As pointed out in the comments, is_open() returns false if the local is open but the remote is not. So what's happening is that the begin/attach frame is send to the peer, we abort, then the peer responds saying it began/attached.

So now I check if the resource is already closed. If it isn't, I attach a listener for the resource's `open` event and call close on that resource if the event is triggered. This ensures that the resource is removed from its parent's state.

I've updated the tests to account for this and ensure that the resources are properly removed from their parent. I also found that in the "pre-cancelled" cases, we were creating the resources and the aborting, rather than just aborting right away, so I've updated this as well.


