### PR TITLE
updates rhea-promise to 2.0.0 to match rhea dependency being updated to 2.x

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### 2.0.0 - (Undeclared)
+### 2.0.0 - (2021-06-03)
 
 - Updates rhea dependency to the 2.x major version, and the tslib dependency to the 2.x major version.
 - Updates `AwaitableSendOptions` to include the optional fields `tag` and `format` which were previously passed to `AwaitableSender.send()`. These fields are no longer positional arguments on `AwaitableSender.send()`.

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,12 @@
 ### 2.0.0 - (2021-06-03)
 
 - Updates rhea dependency to the 2.x major version, and the tslib dependency to the 2.x major version.
-- Updates `AwaitableSendOptions` to include the optional fields `tag` and `format` which were previously passed to `AwaitableSender.send()`. These fields are no longer positional arguments on `AwaitableSender.send()`.
 
-#### Breaking change
+#### Breaking changes
 
 - rhea has 1 breaking change introduced in version 2.x: timestamps are not deserialized as Date objects instead of numbers.
+- Updates `AwaitableSendOptions` to include the optional fields `tag` and `format` which were previously passed to `AwaitableSender.send()`. These fields are no longer positional arguments on `AwaitableSender.send()`.
+- Removes `sendTimeoutInSeconds` from the `AwaitableSendOptions` that is passed to the `AwaitableSender` constructor. `timeoutInSeconds` on `AwaitableSenderOptions` can still be used to set the timeout for individual `AwaitableSender.send()` invocations.
 
 ### 1.2.1 - (2021-04-15)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,90 +1,119 @@
+### 2.0.0 - (Undeclared)
+
+- Updates rhea dependency to the 2.x major version, and the tslib dependency to the 2.x major version.
+- Updates `AwaitableSendOptions` to include the optional fields `tag` and `format` which were previously passed to `AwaitableSender.send()`. These fields are no longer positional arguments on `AwaitableSender.send()`.
+
+#### Breaking change
+
+- rhea has 1 breaking change introduced in version 2.x: timestamps are not deserialized as Date objects instead of numbers.
+
 ### 1.2.1 - (2021-04-15)
 
 - `createSession`, `createReceiver`, and `createSender` methods now only close underlying rhea analogue when cancelled if the resource has already been opened.
 
 ### 1.2.0 - 2021-03-25
+
 - Exposes the `incoming` getter on the `Session` that lets accessing size and capacity of the incoming deliveries [#79](https://github.com/amqp/rhea-promise/pull/79).
 - Updates the error message for the `AbortError` to be a standard message `The operation was aborted.`.
 
 ### 1.1.0 - 2021-02-08
+
 - All async methods now take a signal that can be used to cancel the operation. Fixes [#48](https://github.com/amqp/rhea-promise/issues/48)
 - Added a `timeoutInSeconds` parameter to the `send` method on the `AwaitableSender` that overrides the timeout value for the send operation set when creating the sender.
 - When the `error` event is fired when closing the sender/receiver link, surface errors occurring on the sender/receiver context if none are found on the session context. Details can be found in [PR #55](https://github.com/amqp/rhea-promise/pull/55)
 - Updated minimum version of `rhea` to `^1.0.24`. Details can be found in [PR 68](https://github.com/amqp/rhea-promise/pull/68)
 
 ### 1.0.0 - 2019-06-27
+
 - Updated minimum version of `rhea` to `^1.0.8`.
 - Added a read only property `id` to the `Session` object. The id property is created by concatenating session's local channel, remote channel and the connection id `"local-<number>_remote-<number>_<connection-id>"`, thus making it unique for that connection.
 - Improved log statements by adding the session `id` and the sender, receiver `name` to help while debugging applications.
 - Added `options` to `Link.close({closeSession: true | false})`, thus the user can specify whether the underlying session should be closed while closing the `Sender|Receiver`. Default is `true`.
 - Improved `open` and `close` operations on `Connection`, `Session` and `Link` by creating timer in case the connection gets disconnected. Fixes [#41](https://github.com/amqp/rhea-promise/issues/41).
 - The current `Sender` does not have a provision of **"awaiting"** on sending a message. The user needs to add handlers on the `Sender` for `accepted`, `rejected`, `released`, `modified` to ensure whether the message was successfully sent.
-Now, we have added a new `AwaitableSender` which adds the handlers internally and provides an **awaitable** `send()` operation to the customer. Fixes [#45](https://github.com/amqp/rhea-promise/issues/45).
+  Now, we have added a new `AwaitableSender` which adds the handlers internally and provides an **awaitable** `send()` operation to the customer. Fixes [#45](https://github.com/amqp/rhea-promise/issues/45).
 - Exporting new Errors:
-   - `InsufficientCreditError`: Defines the error that occurs when the Sender does not have enough credit.
-   - `SendOperationFailedError`: Defines the error that occurs when the Sender fails to send a message.
+  - `InsufficientCreditError`: Defines the error that occurs when the Sender does not have enough credit.
+  - `SendOperationFailedError`: Defines the error that occurs when the Sender fails to send a message.
 
 ### 0.2.0 - 2019-05-17
+
 - Updated `OperationTimeoutError` to be a non-AMQP Error as pointed out in [#42](https://github.com/amqp/rhea-promise/issues/42). Fixed in [PR](https://github.com/amqp/rhea-promise/pull/43).
 
 ### 0.1.15 - 2019-04-10
+
 - Export rhea types for `Typed`. [PR](https://github.com/amqp/rhea-promise/pull/36).
-- Export rhea types for `WebSocketImpl` and `WebSocketInstance`.  [PR](https://github.com/amqp/rhea-promise/pull/38).
+- Export rhea types for `WebSocketImpl` and `WebSocketInstance`. [PR](https://github.com/amqp/rhea-promise/pull/38).
 - When opening a connection fails with no error, use standard error message. [PR](https://github.com/amqp/rhea-promise/pull/27).
 
 ### 0.1.14 - 2019-03-19
+
 - Allow websockets usage on a connection without creating a container first. [PR](https://github.com/amqp/rhea-promise/pull/32).
-- New function `removeAllSessions()` on the connection to clear the internal map in rhea to ensure 
-sessions are not reconnected on the next `connection.open()` call. [PR](https://github.com/amqp/rhea-promise/pull/33).
+- New function `removeAllSessions()` on the connection to clear the internal map in rhea to ensure
+  sessions are not reconnected on the next `connection.open()` call. [PR](https://github.com/amqp/rhea-promise/pull/33).
 - Remove all event listeners on link and session objects when `close()` is called on them. [PR](https://github.com/amqp/rhea-promise/pull/34)
 
 ### 0.1.13 - 2018-12-11
+
 - Throw `OperationTimeoutError` when a Promise to create/close an entity is rejected.
 
 ### 0.1.12 - 2018-11-16
+
 - Fix a minor bug in receiver creation.
 
 ### 0.1.11 - 2018-11-15
+
 - Added checks for some event handler methods to exist before logging information that uses node's
-event handlers inbuilt functions.
+  event handlers inbuilt functions.
 - Improved error checking while creating the receiver.
 
 ### 0.1.10 - 2018-11-01
+
 - Provided an option to add an event handler for "settled" event on the Receiver.
 
 ### 0.1.9 - 2018-10-24
+
 - With the usage of `importHelpers`, the tslib will be needed in package.json for installers using older versions of npm (or using yarn). [PR](https://github.com/amqp/rhea-promise/pull/16).
 
 ### 0.1.8 - 2018-10-22
+
 - Allow setting drain property on the receiver [PR](https://github.com/amqp/rhea-promise/pull/14).
 
 ### 0.1.7 - 2018-10-19
+
 - Fixed a bug while populating the connectionId [PR](https://github.com/amqp/rhea-promise/pull/11).
 
 ### 0.1.6 - 2018-09-28
+
 - property `actionInitiated` is now of type `number` which is incremented when the `create`, `close`
-action on an entity is under process and decremented when the action completes (succeeeded or failed).
+  action on an entity is under process and decremented when the action completes (succeeeded or failed).
 
 ### 0.1.5 - 2018-09-27
+
 - Improved log statements for better debugging.
 - Any type of `error` event will be emitted with a tick delay. This would give enough time for the
-`create()` methods to resolve the promise.
+  `create()` methods to resolve the promise.
 - Added a new `boolean` property `actionInitiated` which indicates whether the `create`, `close`
-action on an entity is under process.
+  action on an entity is under process.
 
 ### 0.1.4 - 2018-09-25
+
 - `options` is a required property of `Connection` and `Container`.
 
 ### 0.1.3 - 2018-09-25
+
 - Transform relevant objects in rhea EventContext to rhea-promise objects.
 - Ensure that `container.createConnection()` creates a connection on that container and not on
-the default container.
+  the default container.
 
 ### 0.1.2 - 2018-09-20
+
 - TS target to ES2015. This should help us support node.js version 6.x and above.
 
 ### 0.1.1 - 2018-09-20
+
 - Update homepage, repository and bug urls in package.json
 
 ### 0.1.0 - 2018-09-20
+
 - Initial version of rhea-promise.

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,17 @@
 ### 2.0.0 - (2021-06-03)
 
 - Updates rhea dependency to the 2.x major version, and the tslib dependency to the 2.x major version.
+- Adds `CreateRequestResponseLinkOptions` as an exported interface.
 
 #### Breaking changes
 
 - rhea has 1 breaking change introduced in version 2.x: timestamps are not deserialized as Date objects instead of numbers.
 - Updates `AwaitableSendOptions` to include the optional fields `tag` and `format` which were previously passed to `AwaitableSender.send()`. These fields are no longer positional arguments on `AwaitableSender.send()`.
 - Removes `sendTimeoutInSeconds` from the `AwaitableSendOptions` that is passed to the `AwaitableSender` constructor. `timeoutInSeconds` on `AwaitableSenderOptions` can still be used to set the timeout for individual `AwaitableSender.send()` invocations.
+- Renames the following TypeScript interfaces to better match the methods they apply to:
+   - SenderOptionsWithSession -> CreateSenderOptions
+   - AwaitableSenderOptionsWithSession -> CreateAwaitableSenderOptions
+   - ReceiverOptionsWithSession -> CreateReceiverOptions
 
 ### 1.2.1 - (2021-04-15)
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 
 - rhea has 1 breaking change introduced in version 2.x: timestamps are not deserialized as Date objects instead of numbers.
 - Updates `AwaitableSendOptions` to include the optional fields `tag` and `format` which were previously passed to `AwaitableSender.send()`. These fields are no longer positional arguments on `AwaitableSender.send()`.
+- Adds `SenderSendOptions` to include the optional fields `tag` and `format` which were previously passed to `Sender.send()`. These fields are no longer positional arguments on `Sender.send()`.
 - Removes `sendTimeoutInSeconds` from the `AwaitableSendOptions` that is passed to the `AwaitableSender` constructor. `timeoutInSeconds` on `AwaitableSenderOptions` can still be used to set the timeout for individual `AwaitableSender.send()` invocations.
 - Renames the following TypeScript interfaces to better match the methods they apply to:
    - SenderOptionsWithSession -> CreateSenderOptions

--- a/examples/awaitableSend.ts
+++ b/examples/awaitableSend.ts
@@ -36,7 +36,6 @@ async function main(): Promise<void> {
     target: {
       address: senderAddress
     },
-    sendTimeoutInSeconds: 10
   };
 
   await connection.open();
@@ -51,7 +50,7 @@ async function main(): Promise<void> {
     };
     // Please, note that we are awaiting on sender.send() to complete.
     // You will notice that `delivery.settled` will be `true`, irrespective of whether the promise resolves or rejects.
-    const delivery: Delivery = await sender.send(message);
+    const delivery: Delivery = await sender.send(message, {timeoutInSeconds: 10});
     console.log(
       "[%s] await sendMessage -> Delivery id: %d, settled: %s",
       connection.id,

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -178,8 +178,8 @@ export class AwaitableSender extends BaseSender {
    * @param {Message | Buffer} msg The message to be sent. For default AMQP format msg parameter
    * should be of type Message interface. For a custom format, the msg parameter should be a Buffer
    * and a valid value should be passed to the `format` argument.
-   * @param {AwaitableSendOptions} [options] Options to configure the timeout and cancellation for
-   * the send operation.
+   * @param {AwaitableSendOptions} [options] Options to configure the timeout, cancellation for
+   * the send operation and the tag and message format of the message.
    * @returns {Promise<Delivery>} Promise<Delivery> The delivery information about the sent message.
    */
   send(msg: Message | Buffer, options: AwaitableSendOptions = {}): Promise<Delivery> {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,8 +18,8 @@ export {
 } from "./connection";
 export { Session } from "./session";
 export { Receiver, ReceiverOptions } from "./receiver";
-export { Sender, SenderOptions } from "./sender";
-export { AwaitableSenderOptions, AwaitableSender, PromiseLike } from "./awaitableSender";
+export { Sender, SenderOptions, SenderSendOptions } from "./sender";
+export { AwaitableSenderOptions, AwaitableSender, PromiseLike, AwaitableSendOptions } from "./awaitableSender";
 export { LinkCloseOptions } from "./link";
 export {
   Func, AmqpResponseStatusCode, isAmqpError, ConnectionStringParseOptions, delay, messageHeader,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,7 +14,7 @@ export {
 export { EventContext, OnAmqpEvent } from "./eventContext";
 export { Container, ContainerOptions } from "./container";
 export {
-  Connection, ReqResLink, ConnectionOptions, ReceiverOptionsWithSession, SenderOptionsWithSession
+  Connection, ReqResLink, ConnectionOptions, CreateReceiverOptions, CreateAwaitableSenderOptions, CreateSenderOptions, CreateRequestResponseLinkOptions
 } from "./connection";
 export { Session } from "./session";
 export { Receiver, ReceiverOptions } from "./receiver";

--- a/lib/sender.ts
+++ b/lib/sender.ts
@@ -94,6 +94,19 @@ export class BaseSender extends Link {
   }
 }
 
+export class SenderSendOptions {
+  /**
+   * The message format. Specify this if a message with custom format needs to be sent.
+   * `0` implies the standard AMQP 1.0 defined format. If no value is provided, then the
+   * given message is assumed to be of type Message interface and encoded appropriately.
+   */
+   format?: number;
+   /**
+    * The message tag if any.
+    */
+   tag?: Buffer | string;
+}
+
 /**
  * Describes the AMQP Sender.
  * @class Sender
@@ -109,13 +122,10 @@ export class Sender extends BaseSender {
    * @param {Message | Buffer} msg The message to be sent. For default AMQP format msg parameter
    * should be of type Message interface. For a custom format, the msg parameter should be a Buffer
    * and a valid value should be passed to the `format` argument.
-   * @param {Buffer | string} [tag] The message tag if any.
-   * @param {number} [format] The message format. Specify this if a message with custom format needs
-   * to be sent. `0` implies the standard AMQP 1.0 defined format. If no value is provided, then the
-   * given message is assumed to be of type Message interface and encoded appropriately.
+   * @param {SenderSendOptions} [options] Options to configure the tag and message format of the message.
    * @returns {Delivery} Delivery The delivery information about the sent message.
    */
-  send(msg: Message | Buffer, tag?: Buffer | string, format?: number): Delivery {
-    return (this._link as RheaSender).send(msg, tag, format);
+  send(msg: Message | Buffer, options: SenderSendOptions = {}): Delivery {
+    return (this._link as RheaSender).send(msg, options.tag, options.format);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "rhea-promise",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
     "debug": "^3.1.0",
-    "rhea": "^1.0.24",
-    "tslib": "^1.10.0"
+    "rhea": "^2.0.1",
+    "tslib": "^2.2.0"
   },
   "keywords": [
     "amqp",

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -187,7 +187,7 @@ describe("Connection", () => {
     const session = await connection.createSession();
     assert.isTrue(session.isOpen(), "Session should be open.");
 
-    const requestResponseLink = await connection.createRequestResponseLink({}, {}, session);
+    const requestResponseLink = await connection.createRequestResponseLink({}, {}, {session});
 
     assert.isTrue(requestResponseLink.session.isOpen(), "Session should be open.");
     assert.isTrue(requestResponseLink.receiver.isOpen(), "Receiver should be open.");
@@ -654,7 +654,7 @@ describe("Connection", () => {
 
       // Pass an already aborted signal to createReceiver()
       abortController.abort();
-      const createPromise = connection.createRequestResponseLink({}, {}, undefined, abortSignal);
+      const createPromise = connection.createRequestResponseLink({}, {}, {abortSignal});
 
       let abortErrorThrown = false;
       try {
@@ -678,7 +678,7 @@ describe("Connection", () => {
       const abortSignal = abortController.signal;
 
       // Abort the signal after passing it to createReceiver()
-      const createPromise = connection.createRequestResponseLink({}, {}, undefined, abortSignal);
+      const createPromise = connection.createRequestResponseLink({}, {}, {abortSignal});
       abortController.abort();
 
       let abortErrorThrown = false;

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -43,10 +43,8 @@ describe("Sender", () => {
   });
 
   it("Delivery returned from `AwaitableSender.send()` is not undefined", async () => {
-    const sender = await connection.createAwaitableSender({
-      sendTimeoutInSeconds: 1,
-    });
-    const response = await sender.send({ body: "message" });
+    const sender = await connection.createAwaitableSender();
+    const response = await sender.send({ body: "message" }, { timeoutInSeconds: 1});
     assert.exists(
       response,
       "Response from the AwaitableSender.send() is undefined"

--- a/test/sender.spec.ts
+++ b/test/sender.spec.ts
@@ -175,7 +175,7 @@ describe("Sender", () => {
 
       // Pass an already aborted signal to send()
       abortController.abort();
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, {
+      const sendPromise = sender.send({ body: "hello" }, {
         abortSignal,
       });
 
@@ -206,7 +206,7 @@ describe("Sender", () => {
 
       // Pass an already aborted signal to send()
       abortController.abort();
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, {
+      const sendPromise = sender.send({ body: "hello" }, {
         abortSignal,
       });
 
@@ -233,7 +233,7 @@ describe("Sender", () => {
       const abortSignal = abortController.signal;
 
       // Fire abort signal after passing it to send()
-      const sendPromise = sender.send({ body: "hello" }, undefined, undefined, {
+      const sendPromise = sender.send({ body: "hello" }, {
         abortSignal,
       });
       abortController.abort();


### PR DESCRIPTION
## Description

rhea has been updated to 2.x, so this PR updates rhea-promise to use rhea 2.x!

There was only one breaking change in rhea: deserializing timestamps as dates instead of numbers.

Since we're doing a major version bump of rhea-promise, I also updated AwaitableSender.send to move the optional positional arguments to the options argument.