### PR TITLE
Exposing the new drain_credit() method from rhea

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### 2.1.0 - (2021-06-30)
+
+- Exposes a new `receiver.drainCredit()` method that calls through to rhea's
+  `receiver.drain_credit()` method.
+- Update rhea minimum version to 2.0.3
+
 ### 2.0.0 - (2021-06-03)
 
 - Updates rhea dependency to the 2.x major version, and the tslib dependency to the 2.x major version.
@@ -10,9 +16,9 @@
 - Adds `SenderSendOptions` to include the optional fields `tag` and `format` which were previously passed to `Sender.send()`. These fields are no longer positional arguments on `Sender.send()`.
 - Removes `sendTimeoutInSeconds` from the `AwaitableSendOptions` that is passed to the `AwaitableSender` constructor. `timeoutInSeconds` on `AwaitableSenderOptions` can still be used to set the timeout for individual `AwaitableSender.send()` invocations.
 - Renames the following TypeScript interfaces to better match the methods they apply to:
-   - SenderOptionsWithSession -> CreateSenderOptions
-   - AwaitableSenderOptionsWithSession -> CreateAwaitableSenderOptions
-   - ReceiverOptionsWithSession -> CreateReceiverOptions
+  - SenderOptionsWithSession -> CreateSenderOptions
+  - AwaitableSenderOptionsWithSession -> CreateAwaitableSenderOptions
+  - ReceiverOptionsWithSession -> CreateReceiverOptions
 
 ### 1.2.1 - (2021-04-15)
 

--- a/lib/receiver.ts
+++ b/lib/receiver.ts
@@ -3,7 +3,9 @@
 
 import { Session } from "./session";
 import {
-  ReceiverEvents, Receiver as RheaReceiver, ReceiverOptions as RheaReceiverOptions
+  ReceiverEvents,
+  Receiver as RheaReceiver,
+  ReceiverOptions as RheaReceiverOptions,
 } from "rhea";
 import { Link, LinkType } from "./link";
 import { OnAmqpEvent } from "./eventContext";
@@ -58,7 +60,11 @@ export declare interface Receiver {
  * @class Receiver.
  */
 export class Receiver extends Link {
-  constructor(session: Session, receiver: RheaReceiver, options?: ReceiverOptions) {
+  constructor(
+    session: Session,
+    receiver: RheaReceiver,
+    options?: ReceiverOptions
+  ) {
     super(LinkType.receiver, session, receiver, options);
   }
 
@@ -72,6 +78,10 @@ export class Receiver extends Link {
 
   addCredit(credit: number): void {
     (this._link as RheaReceiver).add_credit(credit);
+  }
+
+  drainCredit(): void {
+    (this._link as RheaReceiver).drain_credit();
   }
 
   setCreditWindow(creditWindow: number): void {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
     "debug": "^3.1.0",
-    "rhea": "^2.0.1",
+    "rhea": "^2.0.3",
     "tslib": "^2.2.0"
   },
   "keywords": [


### PR DESCRIPTION
The latest release of rhea (2.0.3) now has a method that will let you drain credits without calling add_credit(). 

This is part of a fix for a bug in Service Bus [#15989](https://github.com/Azure/azure-sdk-for-js/pull/15989).