### PR TITLE
Fix issue where Connection constructor is not setting operationTimeoutInSeconds option correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 3.0.1 - (Unreleased)
+
+- Fix a bug where `Connection` constructor isn't setting `operationTimeoutInSeconds` correctly.
+
 ### 3.0.0 - (2023-03-02)
 
 - Update `rhea` dependency to the 3.x major version.

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -237,6 +237,9 @@ export class Connection extends Entity {
     } else {
       let connectionOptions = options as ConnectionOptions;
       if (!connectionOptions) connectionOptions = { transport: "tls" };
+      if (!connectionOptions.operationTimeoutInSeconds) {
+        connectionOptions.operationTimeoutInSeconds = defaultOperationTimeoutInSeconds;
+      }
       if (connectionOptions.webSocketOptions) {
         const ws = websocket_connect(connectionOptions.webSocketOptions.webSocket);
         (connectionOptions.connection_details as any) = ws(

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -237,9 +237,6 @@ export class Connection extends Entity {
     } else {
       let connectionOptions = options as ConnectionOptions;
       if (!connectionOptions) connectionOptions = { transport: "tls" };
-      if (connectionOptions.operationTimeoutInSeconds == undefined) {
-        connectionOptions.operationTimeoutInSeconds = defaultOperationTimeoutInSeconds;
-      }
       if (connectionOptions.webSocketOptions) {
         const ws = websocket_connect(connectionOptions.webSocketOptions.webSocket);
         (connectionOptions.connection_details as any) = ws(
@@ -253,7 +250,7 @@ export class Connection extends Entity {
     }
 
     this.options = this._connection.options;
-    this.options.operationTimeoutInSeconds = options.operationTimeoutInSeconds;
+    this.options.operationTimeoutInSeconds = options?.operationTimeoutInSeconds ?? defaultOperationTimeoutInSeconds;
 
     this._initializeEventListeners();
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -702,6 +702,14 @@ describe("Connection", () => {
       assert.equal(30, connection["options"].operationTimeoutInSeconds);
     });
 
+    it("constructor sets operationTimeoutInSeconds option when passing a ConnectionOptions with undefined operationTimeoutInSeconds", () => {
+      const connectionOptions: ConnectionOptions = {
+        transport: "tls",
+      }
+      const connection = new Connection(connectionOptions);
+      assert.equal(60, connection["options"].operationTimeoutInSeconds);
+    });
+
     it("constructor sets operationTimeoutInSeconds option when not passing any options", () => {
       const connection = new Connection();
       assert.equal(60, connection["options"].operationTimeoutInSeconds);
@@ -717,6 +725,17 @@ describe("Connection", () => {
       };
       const connection = new Connection(createdRheaConnectionOptions);
       assert.equal(20, connection["options"].operationTimeoutInSeconds);
+    });
+
+    it("constructor sets operationTimeoutInSeconds option when passing a CreatedRheaConnectionOptions with undefined operationTimeoutInSeconds", () => {
+      const container = new Container();
+      const rheaConnection = rhea.create_connection();
+      const createdRheaConnectionOptions: CreatedRheaConnectionOptions = {
+        rheaConnection,
+        container,
+      };
+      const connection2 = new Connection(createdRheaConnectionOptions);
+      assert.equal(60, connection2["options"].operationTimeoutInSeconds);
     });
   })
 });

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -1,8 +1,9 @@
 import * as rhea from "rhea";
 import { assert } from "chai";
-import { Connection, ConnectionEvents } from "../lib/index";
+import { Connection, ConnectionEvents, ConnectionOptions, Container } from "../lib/index";
 import { AbortController } from "@azure/abort-controller";
 import { abortErrorName } from "../lib/util/utils";
+import { CreatedRheaConnectionOptions } from "../lib/connection";
 
 describe("Connection", () => {
   let mockService: rhea.Container;
@@ -690,6 +691,32 @@ describe("Connection", () => {
 
       assert.isTrue(abortErrorThrown, "AbortError should have been thrown.");
       await connection.close();
+    });
+
+    it("constructor sets operationTimeoutInSeconds option when passing a ConnectionOptions", () => {
+      const connectionOptions: ConnectionOptions = {
+        operationTimeoutInSeconds: 30,
+        transport: "tls",
+      }
+      const connection = new Connection(connectionOptions);
+      assert.equal(30, connection["options"].operationTimeoutInSeconds);
+    });
+
+    it("constructor sets operationTimeoutInSeconds option when not passing any options", () => {
+      const connection = new Connection();
+      assert.equal(60, connection["options"].operationTimeoutInSeconds);
+    });
+
+    it("constructor sets operationTimeoutInSeconds option when passing a CreatedRheaConnectionOptions", () => {
+      const container = new Container();
+      const rheaConnection = rhea.create_connection();
+      const createdRheaConnectionOptions: CreatedRheaConnectionOptions = {
+        operationTimeoutInSeconds: 20,
+        rheaConnection,
+        container,
+      };
+      const connection = new Connection(createdRheaConnectionOptions);
+      assert.equal(20, connection["options"].operationTimeoutInSeconds);
     });
   })
 });


### PR DESCRIPTION
## Description

The regression was introduced in PR #93 when adapting to rhea v3 typing changes.

## Reference to any github issues
- #98 
