### PR TITLE
Add a workflow to draft release on pushed `v*` tag

### DIFF
--- a/.github/workflows/draft-release-on-tag.yml
+++ b/.github/workflows/draft-release-on-tag.yml
@@ -1,0 +1,31 @@
+name: Draft Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    permissions: write-all
+    name: Draft Release on Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm pack
+      - name: Draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ github.event.ref }}
+        run: |
+          tag=${REF##*/}
+
+          gh release create "${tag}" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${GITHUB_REPOSITORY#*/} ${tag#v}" \
+              --generate-notes \
+              --draft \
+              ./*.tgz


### PR DESCRIPTION
## Description

Add a GitHub workflow to create a draft release whenever a tag of `v*` format is pushed.  This should make releasing a little easier.

The created drafts look like

https://github.com/jeremymeng/rhea-promise/releases/tag/untagged-e8fce60330d0ecc5db4e

Triggered action would be similar to

https://github.com/jeremymeng/rhea-promise/actions/runs/4888369100
