### PR TITLE
Update docs to use timeoutInSeconds from AwaitableSenderOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ async function main(): Promise<void> {
     target: {
       address: senderAddress
     },
-    sendTimeoutInSeconds: 10
   };
 
   await connection.open();
@@ -195,7 +194,9 @@ async function main(): Promise<void> {
     };
     // Note: Here we are awaiting for the send to complete.
     // You will notice that `delivery.settled` will be `true`, irrespective of whether the promise resolves or rejects.
-    const delivery: Delivery = await sender.send(message);
+    const delivery: Delivery = await sender.send(message, {
+      timeoutInSeconds: 10
+    });
     console.log(
       "[%s] await sendMessage -> Delivery id: %d, settled: %s",
       connection.id,


### PR DESCRIPTION
`sendTimeoutInSeconds` was removed from `AwaitableSendOptions` in v2.0, and replaced with `timeoutInSeconds` in `AwaitableSenderOptions`. See commit a93f885a5c9a30e21d8a831c3c9aba148dc79567

This PR updates README.md to reflect this change, and is also consistent with the example file at [/examples/awaitableSend.ts](https://github.com/amqp/rhea-promise/blob/master/examples/awaitableSend.ts)