### PR TITLE
Set the max listener limit to 1000 for `RheaConnection`

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -202,6 +202,8 @@ export declare interface Connection {
   on(event: ConnectionEvents, listener: OnAmqpEvent): this;
 }
 
+const maxListenerLimit = 1000;
+
 /**
  * Describes the AMQP Connection.
  * @class Connection
@@ -256,6 +258,10 @@ export class Connection extends Entity {
     this.options.operationTimeoutInSeconds = options?.operationTimeoutInSeconds ?? defaultOperationTimeoutInSeconds;
 
     this._initializeEventListeners();
+
+    // Set max listeners on the connection to 1000 because Session and Link add their own listeners
+    // and the default value of 10 in NodeJS is too low.
+    this._connection.setMaxListeners(maxListenerLimit);
   }
 
   /**


### PR DESCRIPTION
## Description

NodeJS would issue warning if the number of disconnected listeners on an event emitter exceeds 10. When many sessions or links on a connection are closed at the same time, we will see this warning because the default limit of 10 in NodeJS is too low. The disconnected listeners DO get removed eventually.

This causes Azure/azure-sdk-for-js#29186 when it stops all its `Link` objects at the same time.
(Source links: [`Link.stop` call](https://github.com/Azure/azure-sdk-for-js/blob/7cdf35cbe2596476c16d2bb85c31bd89375e4faf/sdk/eventhub/event-hubs/src/partitionReceiver.ts#L134-L135), [the loop](https://github.com/Azure/azure-sdk-for-js/blob/7cdf35cbe2596476c16d2bb85c31bd89375e4faf/sdk/eventhub/event-hubs/src/pumpManager.ts#L175-L180))

`azure-sdk-for-js` [already raises the limit this for some other objects](https://github.com/Azure/azure-sdk-for-js/blob/7cdf35cbe2596476c16d2bb85c31bd89375e4faf/sdk/core/core-amqp/src/ConnectionContextBase.ts#L124). Since `Connection._connection` is private and the `disconnect` listeners are an implementation detail of `rhea-promise`, I felt it was more appropriate to address it here.

There's also a draft PR #78 from 2021 trying to address this issue, but it looks a lot like (partially) reimplementing `EventEmitter` just to remove the listener warning. That's why I ultimately decided to go with `setMaxListeners`.

Brief description of the changes made in the PR. This helps in making better changelog
- Fixes `MaxListenersExceededWarning` when closing multiple links or sessions.

## Reference to any github issues
- Azure/azure-sdk-for-js#29186
