### PR TITLE
Fix an issue where links are kept alive

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 3.0.3 - (2024-06-12)
+
+- Release the resources if `Session.createReceiver()` rejects due to timeout.
+
 ### 3.0.2 - (2024-05-02)
 
 - Set the max listener limit to 1000 for `RheaConnection`

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License. See License in the project root for license information.
 
 import * as log from "./log";
-import { Connection } from "./connection";
+import { Connection, CreateReceiverOptions } from "./connection";
 import { Receiver, ReceiverOptions } from "./receiver";
 import { Sender, SenderOptions } from "./sender";
 import {
@@ -396,6 +396,15 @@ export class Session extends Entity {
         const msg: string = `Unable to create the amqp receiver '${receiver.name}' on amqp ` +
           `session '${this.id}' due to operation timeout.`;
         log.error("[%s] %s", this.connection.id, msg);
+
+        const createReceiverOptions = options as CreateReceiverOptions;
+        if (createReceiverOptions?.session?.createReceiver) {
+          // being called on a session passed via the options so don't close the session
+          receiver.close({ closeSession: false }).then(() => { receiver.remove(); })
+        } else {
+          receiver.close({ closeSession: true }).then(() => { receiver.remove(); })
+        }
+
         return reject(new OperationTimeoutError(msg));
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",


### PR DESCRIPTION
even though we are unable to create an Amqp receiver due to operation timeout.

The problem is that `rheaReceiver` and `receiver` are created when the Promise
instance is created, however, they are not removed when rejecting due to
operation timeout. So the created objects are kept by `rhea` as long as the
connection is alive but not usable by any. In this case there's no way for outside 
caller to do the clean up because `receiver` is not returned by the `resolve` callback.

This PR adds cleanup for the `actionAfterTimeout` code path.