### PR TITLE
Update awaitableSender to handle disconnection while sending

### DIFF
--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -204,7 +204,7 @@ export class AwaitableSender extends BaseSender {
               `'${this.session.id}' was not able to send the message with delivery id ${delivery.id} ` +
               `right now, due to the fact that the sender link is closed.`;
             log.error("[%s] %s", this.connection.id, message);
-            return reject(new SendOperationFailedError(message));
+            return reject(new Error(message));
           }
           const message = `Sender '${this.name}' on amqp session ` +
             `'${this.session.id}', with address '${this.address}' was not able to send the ` +

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -199,6 +199,13 @@ export class AwaitableSender extends BaseSender {
       if (this.sendable()) {
         const timer = setTimeout(() => {
           this.deliveryDispositionMap.delete(delivery.id);
+          if (!this.source) {
+            const message = `Sender '${this.name}' on amqp session ` +
+              `'${this.session.id}' was not able to send the message with delivery id ${delivery.id} ` +
+              `right now, due to the fact that the sender link is closed.`;
+            log.error("[%s] %s", this.connection.id, message);
+            return reject(new OperationTimeoutError(message));
+          }
           const message = `Sender '${this.name}' on amqp session ` +
             `'${this.session.id}', with address '${this.address}' was not able to send the ` +
             `message with delivery id ${delivery.id} right now, due to operation timeout.`;

--- a/lib/awaitableSender.ts
+++ b/lib/awaitableSender.ts
@@ -204,7 +204,7 @@ export class AwaitableSender extends BaseSender {
               `'${this.session.id}' was not able to send the message with delivery id ${delivery.id} ` +
               `right now, due to the fact that the sender link is closed.`;
             log.error("[%s] %s", this.connection.id, message);
-            return reject(new OperationTimeoutError(message));
+            return reject(new SendOperationFailedError(message));
           }
           const message = `Sender '${this.name}' on amqp session ` +
             `'${this.session.id}', with address '${this.address}' was not able to send the ` +


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- AwaitableSender: if connection is lost (disconnected event) while sending a message, operation timeout will be triggered and this.source will be undefined due to frame detach
- then this.address which is this.source.address will throw error which should be properly handled by the library
- applications using awaitableSender will crashed due to the above
- the version we're using is 2.1.0

## Reference to any github issues
- https://github.com/amqp/rhea-promise/issues/109

@jeremymeng as you're the most recent contributor, thanks for the help:)
