### PR TITLE
Bump supported Node.js to 22 and release 3.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Promisified layer over [rhea](https://github.com/amqp/rhea) AMQP client.
 
 ## Pre-requisite ##
-- **Node.js version: 20.x or higher.** 
+- **Node.js version: 22.x or higher.** 
 - We would **still encourage you** to install the latest available LTS version at any given time from https://nodejs.org. **It is a good practice to always install the latest available LTS version of node.js.**
 - Installing node.js on **Windows or macOS** is very simple with available installers on the [node.js website](https://nodejs.org). If you are using a **linux based OS**, then you can find easy to follow, one step installation instructions over [here](https://nodejs.org/en/download/package-manager/).
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 ### 3.0.4 - (Unreleased)
 
+- Fix `AwaitableSender.send()` to reject with a clear error when the sender link is closed (e.g. due to a disconnection) while sending, instead of failing with a generic operation timeout.
+- Update minimum supported Node.js version to 22.x. Node 16, 18, and 20 are no longer supported.
 - Upgrade TypeScript to 6.0 and switch `module` to `nodenext` to remove auto-generated `/// <reference types="node" />` directives from typings.
-- Update minimum Node.js version to 20.x (Node 16 and 18 are EOL).
-- Update `@types/node` to ^20.0.0.
+- Update `@types/node` to ^22.0.0.
 
 ### 3.0.3 - (2024-06-12)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhea-promise",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhea-promise",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
@@ -17,7 +17,7 @@
         "@eslint/js": "^10.0.1",
         "@microsoft/api-extractor": "^7.58.7",
         "@types/debug": "^4.1.13",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "dotenv": "^17.4.2",
         "eslint": "^10.3.0",
         "eslint-plugin-jsdoc": "^62.9.0",
@@ -499,9 +499,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -519,9 +516,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -539,9 +533,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -559,9 +550,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -579,9 +567,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -599,9 +584,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -867,9 +849,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhea-promise",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A Promisified layer over rhea AMQP client",
   "license": "Apache-2.0",
   "main": "./dist/lib/index.js",
@@ -28,7 +28,7 @@
     "@eslint/js": "^10.0.1",
     "@microsoft/api-extractor": "^7.58.7",
     "@types/debug": "^4.1.13",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "dotenv": "^17.4.2",
     "eslint": "^10.3.0",
     "eslint-plugin-jsdoc": "^62.9.0",


### PR DESCRIPTION
## Summary

Bumps the supported Node.js version to 22, releases version 3.0.4, and records the meaningful customer-facing changes in the changelog.

## Changes

- **Node.js support**: minimum supported version raised to **22.x** (Node 16, 18, and 20 are no longer supported).
  - README pre-requisite updated to 22.x or higher.
  - CI matrix updated to `[22.x, 24.x, 26.x]`.
  - `@types/node` bumped to `^22.0.0` (lockfile updated).
- **Version**: `package.json` bumped to **3.0.4**.
- **Changelog**: added a customer-impacting entry for the `AwaitableSender.send()` fix (#119) that now rejects with a clear error when the sender link is closed during send instead of a generic operation timeout, plus the Node 22 / `@types/node` updates.

## Notes

Dependencies could not be installed in this environment (TLS egress to the npm registry CDN is blocked, affecting all tarball downloads), so `npm run build`/tests were not run here. The lockfile was updated via metadata-only resolution. CI will validate the build across the new Node matrix.